### PR TITLE
bump liftoff and v8flags

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ var cli = new Liftoff({
   name: 'gulp',
   completions: completion,
   extensions: interpret.jsVariants,
-  nodeFlags: v8flags.fetch()
+  v8flags: v8flags
 });
 
 // exit with 0 or 1

--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
     "chalk": "^0.5.0",
     "gulp-util": "^3.0.0",
     "interpret": "^0.4.1",
-    "liftoff": "^1.0.0",
+    "liftoff": "^2.0.0",
     "minimist": "^1.1.0",
     "pretty-hrtime": "^0.2.0",
     "semver": "^4.1.0",
     "tildify": "^1.0.0",
-    "v8flags": "^1.0.1"
+    "v8flags": "^2.0.0"
   },
   "devDependencies": {
     "6to5": "^2.9.4",


### PR DESCRIPTION
this should solve all of the wack installation issues we were
seeing on windows machines, and work correctly with io.js.

- v8flags is now async
- v8flags caches flags at first run, not on installation
- liftoff `nodeFlags` was renamed to `v8flags` for accuracy