### PR TITLE
Improve task not found messaging

### DIFF
--- a/lib/versioned/^4.0.0-alpha.1/index.js
+++ b/lib/versioned/^4.0.0-alpha.1/index.js
@@ -64,9 +64,7 @@ function execute(opts, env) {
       });
     } catch (err) {
       log.error(chalk.red(err.message));
-      log.error(
-        'Please check the documentation for proper gulpfile formatting'
-      );
+      log.error('To list available tasks, try running: gulp --tasks');
       exit(1);
     }
   });


### PR DESCRIPTION
This advice seems more-likely to be helpful when mistakenly referencing unknown tasks.

Related to https://github.com/gulpjs/gulp/pull/1388