### PR TITLE
Fixed AppVeyor errors.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ install:
 test_script:
   - node --version
   - npm --version
-  - npm test
+  - for %%f in (test\*.js) do node_modules\.bin\lab %%f -v -m 5000 & if errorlevel 1 exit /b 1
 
 build: off
 

--- a/test/completion.js
+++ b/test/completion.js
@@ -5,11 +5,27 @@ var code = require('code');
 
 var child = require('child_process');
 
+var fs = require('fs-extra');
+var path = require('path');
+
+var outfile = path.resolve(__dirname, 'output/completion.out');
+
 lab.experiment('flag: --completion', function() {
+
+  lab.before(function(done) {
+    fs.mkdirpSync(path.resolve(__dirname, 'output'));
+    done();
+  });
+
+  lab.after(function(done) {
+    fs.remove(path.resolve(__dirname, 'output'));
+    done();
+  });
 
   ['bash', 'fish', 'powershell', 'zsh'].forEach(function(type) {
     lab.test('returns completion script for ' + type, function(done) {
-      child.exec('node ' + __dirname + '/../bin/gulp.js --completion=' + type, function(err, stdout) {
+      child.exec('node ' + __dirname + '/../bin/gulp.js --completion=' + type + ' > ' + outfile, function(err) {
+        var stdout = fs.readFileSync(outfile, { encoding: 'utf8' });
         code.expect(stdout).to.contain('gulp --completion=' + type);
         done(err);
       });
@@ -17,7 +33,8 @@ lab.experiment('flag: --completion', function() {
   });
 
   lab.test('shows error message for unknown completion type', function(done) {
-    child.exec('node ' + __dirname + '/../bin/gulp.js --completion=unknown', function(err, stdout) {
+    child.exec('node ' + __dirname + '/../bin/gulp.js --completion=unknown > ' + outfile, function() {
+      var stdout = fs.readFileSync(outfile, { encoding: 'utf8' });
       code.expect(stdout).to.contain('rules for \'unknown\' not found');
       done();
     });

--- a/test/flags-help.js
+++ b/test/flags-help.js
@@ -3,22 +3,37 @@
 var lab = exports.lab = require('lab').script();
 var code = require('code');
 
-var fs = require('fs');
+var fs = require('fs-extra');
 var child = require('child_process');
+
+var path = require('path');
+var outfile = path.resolve(__dirname, 'output/flags-help.out');
 
 var output = fs.readFileSync(__dirname + '/expected/flags-help.txt', 'utf8').replace(/(\r\n|\n|\r)\s?/gm,'\n');
 
 lab.experiment('flag: help', function() {
 
+  lab.before(function(done) {
+    fs.mkdirpSync(path.resolve(__dirname, 'output'));
+    done();
+  });
+
+  lab.after(function(done) {
+    fs.removeSync(path.resolve(__dirname, 'output'));
+    done();
+  });
+
   lab.test('shows help using --help', function(done) {
-    child.exec('node ' + __dirname + '/../bin/gulp.js --help --cwd ./test/fixtures', function(err, stdout) {
+    child.exec('node ' + __dirname + '/../bin/gulp.js --help --cwd ./test/fixtures > ' + outfile, function(err) {
+      var stdout = fs.readFileSync(outfile, { encoding: 'utf8' });
       code.expect(stdout.replace(/(\r\n|\n|\r)\s?/gm,'\n')).to.equals(output);
       done(err);
     });
   });
 
   lab.test('shows help using short --h', function(done) {
-    child.exec('node ' + __dirname + '/../bin/gulp.js --h --cwd ./test/fixtures', function(err, stdout) {
+    child.exec('node ' + __dirname + '/../bin/gulp.js --h --cwd ./test/fixtures > ' + outfile, function(err) {
+      var stdout = fs.readFileSync(outfile, { encoding: 'utf8' });
       code.expect(stdout.replace(/(\r\n|\n|\r)\s?/gm,'\n')).to.equals(output);
       done(err);
     });

--- a/test/flags-tasks-json.js
+++ b/test/flags-tasks-json.js
@@ -11,12 +11,12 @@ var output = require('./expected/flags-tasks-json.json');
 
 lab.experiment('flag: --tasks-json', function() {
 
-  var outputString = JSON.stringify(output).replace(/{{path}}/, tildify(path.join(__dirname, 'fixtures/gulpfile.js')));
+  var outputString = JSON.stringify(output).replace(/{{path}}/, tildify(path.join(__dirname, 'fixtures/gulpfile.js')).replace(/\\/g, '\\\\'));
   var expected = JSON.parse(outputString);
 
   lab.test('prints the task list with no args', function(done) {
     child.exec('node ' + __dirname + '/../bin/gulp.js --tasks-json --gulpfile "./test/fixtures/gulpfile.js" ', function(err, stdout) {
-      stdout = stdout.replace(/\\/g, '/').split('\n');
+      stdout = stdout.split('\n');
       var parsedJson = JSON.parse(stdout[1]);
       code.expect(parsedJson).to.deep.equal(expected);
       done(err);


### PR DESCRIPTION
Since some test codes caused errors on AppVeyor, I've fixed them.

Modification:

  * appveyor.yml
    Use `for` statement because the wildcard in `npm test` was not expanded. (But coverage is unavailable).

  * test/completion.js
    Change stdout handling to reading a redirected file because the argument for stdout was empty on node v0.10 for Windows.

  * test/flags-help.js
    Change stdout handling to reading a redirected file because the argument for stdout contained strange strings in the tail on node v0.10 for Windows.

  * test/flags-tasks-json.js
    Add escaping backslashes in `outputString` to eliminate `JSON.parse` errors on Windows, and remove replacing backslashes to slashes in `stdout`.