### PR TITLE
add displayName support to exported tasks

### DIFF
--- a/lib/shared/registerExports.js
+++ b/lib/shared/registerExports.js
@@ -14,7 +14,7 @@ function registerExports(gulpInst, tasks) {
       return;
     }
 
-    gulpInst.task(taskName, task);
+    gulpInst.task(task.displayName || taskName, task);
   }
 }
 


### PR DESCRIPTION
I can't find the exact place with the documentation, but I read somewhere that the task name can be be set using the displayName property on the function. The description property is already working correctly. And displayName is handled correctly elsewhere, (e.g. gulp.parallel)

This small change should fix this.