### PR TITLE
Ensure that all tasks exit

### DIFF
--- a/lib/versioned/^4.0.0-alpha.2/index.js
+++ b/lib/versioned/^4.0.0-alpha.2/index.js
@@ -69,6 +69,7 @@ function execute(opts, env) {
         if (err) {
           exit(1);
         }
+        exit(0);
       });
     } catch (err) {
       log.error(chalk.red(err.message));


### PR DESCRIPTION
I've found that on the odd occasion that the cli takes an extended
period of time to exit.

After a fair amount of testing I can confirm that all of the
`async-done` handles do correctly complete, however, upon using
[wtfnode](https://www.npmjs.com/package/wtfnode) I found that there are
a few results that are keeping the cli open.

> [WTF Node?] open handles:
> - Sockets:
>   - undefined:undefined -> undefined:undefined
>     - Listeners:
>   - undefined:undefined -> undefined:undefined
>     - Listeners:
> - Timers:
>   - (30000 ~ 30 s) bound cleanupWebsocketResources @ $PWD/node_modules/engine.io/node_modules/ws/lib/Sender.js:59

Adding `exit(0)` resolves these issues.