### PR TITLE
Update dependencies

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,3 @@
+version: v1
+ignore: {}
+patch: {}

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lint": "eslint . && jscs index.js bin/ lib/ test/",
     "prepublish": "marked-man --name gulp docs/CLI.md > gulp.1",
     "pretest": "npm run lint",
-    "test": "lab test/*.js -cv",
+    "test": "snyk test && lab test/*.js -cv",
     "changelog": "github-changes -o gulpjs -r gulp-cli -b master -f ./CHANGELOG.md --order-semver --use-commit-body"
   },
   "dependencies": {
@@ -42,22 +42,23 @@
     "mute-stdout": "^1.0.0",
     "pretty-hrtime": "^1.0.0",
     "semver-greatest-satisfied-range": "^1.0.0",
+    "snyk": "^1.14.3",
     "tildify": "^1.0.0",
     "v8flags": "^2.0.9",
     "wreck": "^6.3.0",
-    "yargs": "^3.28.0"
+    "yargs": "^3.32.0"
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.5.0",
     "babel-register": "^6.5.1",
     "code": "^1.2.1",
     "coveralls": "^2.7.0",
-    "eslint": "^1.7.3",
+    "eslint": "^1.10.3",
     "eslint-config-gulp": "^2.0.0",
-    "fs-extra": "^0.26.1",
+    "fs-extra": "^0.30.0",
     "github-changes": "^1.0.1",
     "gulp": "gulpjs/gulp#4.0",
-    "jscs": "^2.3.5",
+    "jscs": "^3.0.3",
     "jscs-preset-gulp": "^1.0.0",
     "lab": "^6.2.0",
     "marked-man": "^0.1.3"


### PR DESCRIPTION
Update dependencies to latest published version where possible without introducing breaking changes.

Add `snyk` for vulnerability checking (exluding devDependencies).