### PR TITLE
Args implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 sudo: false
 language: node_js
 node_js:
-  - "stable"
-  - "4"
-  - "0.12"
-  - "0.10"
+  - 6
+  - 5
+  - 4
 before_script:
   - sed -i 's/4.0.0-alpha.1/4.0.0/g' node_modules/gulp/package.json
 after_script:

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
 
 # gulp-cli
 
-[![NPM version][npm-image]][npm-url] [![Downloads][downloads-image]][npm-url] [![Build Status][travis-image]][travis-url] [![AppVeyor Build Status][appveyor-image]][appveyor-url] [![Coveralls Status][coveralls-image]][coveralls-url] [![Gitter chat][gitter-image]][gitter-url]
+[![npm version][npm-image]][npm-url] [![Downloads][downloads-image]][npm-url] [![Build Status][travis-image]][travis-url] [![AppVeyor Build Status][appveyor-image]][appveyor-url] [![Coveralls Status][coveralls-image]][coveralls-url] [![Gitter chat][gitter-image]][gitter-url]
 
 Command Line Utility for Gulp
 
 ## Usage
 
 ```bash
-> gulp [flags] tasks
+$ gulp [flags] tasks
 ```
 
 ## Custom Metadata

--- a/README.md
+++ b/README.md
@@ -64,9 +64,13 @@ The CLI adds process.env.INIT_CWD which is the original cwd it was launched from
 
 ## Flags
 
-Gulp has very few flags to know about. All other flags are for tasks to use if needed. But beware, **some flags only work with gulp 4 and will be ignored when invoked against gulp 3**.
+Gulp has very few flags to know about. All other flags are for tasks to use if needed. Simply run this command to list all available flags:
 
-Simply run this command to list all available flags: `gulp help`
+```bash
+gulp help
+```
+
+But beware, some flags only work with gulp 4 and will be ignored when invoked against gulp 3. 
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The CLI adds process.env.INIT_CWD which is the original cwd it was launched from
 Gulp has very few flags to know about. All other flags are for tasks to use if needed. Simply run this command to list all available flags and commands:
 
 ```bash
-gulp help
+$ gulp help
 ```
 
 But beware, some flags only work with gulp 4 and will be ignored when invoked against gulp 3.

--- a/README.md
+++ b/README.md
@@ -64,17 +64,13 @@ The CLI adds process.env.INIT_CWD which is the original cwd it was launched from
 
 ## Flags
 
-Gulp has very few flags to know about. All other flags are for tasks to use if needed. Simply run this command to list all available flags:
+Gulp has very few flags to know about. All other flags are for tasks to use if needed. Simply run this command to list all available flags and commands:
 
 ```bash
 gulp help
 ```
 
-But beware, some flags only work with gulp 4 and will be ignored when invoked against gulp 3. 
-
-## License
-
-MIT
+But beware, some flags only work with gulp 4 and will be ignored when invoked against gulp 3.
 
 [gittip-url]: https://www.gittip.com/WeAreFractal/
 [gittip-image]: http://img.shields.io/gittip/WeAreFractal.svg

--- a/README.md
+++ b/README.md
@@ -64,96 +64,9 @@ The CLI adds process.env.INIT_CWD which is the original cwd it was launched from
 
 ## Flags
 
-gulp has very few flags to know about. All other flags are for tasks to use if needed.
+Gulp has very few flags to know about. All other flags are for tasks to use if needed. But beware, **some flags only work with gulp 4 and will be ignored when invoked against gulp 3**.
 
-__Some flags only work with gulp 4 and will be ignored when invoked against gulp 3.__
-
-<table>
-  <thead>
-    <tr>
-      <th width="25%">Flag</th>
-      <th width="15%">Short Flag</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>--help</td>
-      <td>-h</td>
-      <td>Show this help.</td>
-    </tr>
-    <tr>
-      <td>--version</td>
-      <td>-v</td>
-      <td>Print the global and local gulp versions.</td>
-    </tr>
-    <tr>
-      <td>--require [path]</td>
-      <td></td>
-      <td>Will require a module before running the gulpfile. This is useful for transpilers but also has other applications.</td>
-    </tr>
-    <tr>
-      <td>--gulpfile [path]</td>
-      <td></td>
-      <td>Manually set path of gulpfile. Useful if you have multiple gulpfiles. This will set the CWD to the gulpfile directory as well.</td>
-    </tr>
-    <tr>
-      <td>--cwd [path]</td>
-      <td></td>
-      <td>Manually set the CWD. The search for the gulpfile, as well as the relativity of all requires will be from here.</td>
-    </tr>
-    <tr>
-      <td>--verify [path (optional)]</td>
-      <td></td>
-      <td>Will verify plugins referenced in project's package.json against the plugins blacklist.</td>
-    </tr>
-    <tr>
-      <td>--tasks</td>
-      <td>-T</td>
-      <td>Print the task dependency tree for the loaded gulpfile.</td>
-    </tr>
-    <tr>
-      <td>--depth [number]</td>
-      <td></td>
-      <td>Specify the depth of the task dependency tree to print.</td>
-    </tr>
-    <tr>
-      <td>--tasks-simple</td>
-      <td></td>
-      <td>Print a plaintext list of tasks for the loaded gulpfile.</td>
-    </tr>
-    <tr>
-      <td>--tasks-json [path]</td>
-      <td></td>
-      <td>Print the task dependency tree, in JSON format, for the loaded gulpfile. The [path] argument is optional, and if given writes the JSON to the path.</td>
-    </tr>
-    <tr>
-      <td>--color</td>
-      <td></td>
-      <td>Will force gulp and gulp plugins to display colors, even when no color support is detected.</td>
-    </tr>
-    <tr>
-      <td>--no-color</td>
-      <td></td>
-      <td>Will force gulp and gulp plugins to not display colors, even when color support is detected.</td>
-    </tr>
-    <tr>
-      <td>--silent</td>
-      <td>-S</td>
-      <td>Suppress all gulp logging.</td>
-    </tr>
-    <tr>
-      <td>--continue</td>
-      <td></td>
-      <td>Continue execution of tasks upon failure.</td>
-    </tr>
-    <tr>
-      <td>--log-level</td>
-      <td>-L</td>
-      <td>Set the loglevel. -L for least verbose and -LLLL for most verbose. -LLL is default.</td>
-    </tr>
-  </tbody>
-</table>
+Simply run this command to list all available flags: `gulp help`
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ var args = require('args');
 
 for (var option in cliOptions) {
   var details = cliOptions[option];
-  var name = details.short ? [details.name, details.short] : details.name;
+  var name = details.short ? [details.short, details.name] : details.name;
 
   args.option(name, details.description);
 }

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ for (var option in cliOptions) {
   var details = cliOptions[option];
   var name = details.short ? [details.short, details.name] : details.name;
 
-  args.option(name, details.description);
+  args.option(name, details.description, details.pre, details.init);
 }
 
 var opts = args.parse(process.argv, {

--- a/index.js
+++ b/index.js
@@ -1,11 +1,10 @@
 #!/usr/bin/env node
-
 'use strict';
+
 var fs = require('fs');
 var path = require('path');
 var log = require('gulplog');
 var chalk = require('chalk');
-var yargs = require('yargs');
 var Liftoff = require('liftoff');
 var tildify = require('tildify');
 var interpret = require('interpret');
@@ -18,6 +17,19 @@ var verifyDeps = require('./lib/shared/verifyDependencies');
 var cliVersion = require('./package.json').version;
 var getBlacklist = require('./lib/shared/getBlacklist');
 var toConsole = require('./lib/shared/log/toConsole');
+var args = require('args');
+
+for (var option in cliOptions) {
+  var details = cliOptions[option];
+  var name = details.short ? [details.name, details.short] : details.name;
+
+  args.option(name, details.description);
+}
+
+var opts = args.parse(process.argv, {
+  version: false,
+  value: '<tasks>'
+});
 
 // Logging functions
 var logVerify = require('./lib/shared/log/verify');
@@ -36,13 +48,6 @@ var cli = new Liftoff({
   extensions: interpret.jsVariants,
   v8flags: v8flags,
 });
-
-var usage =
-  '\n' + chalk.bold('Usage:') +
-  ' gulp ' + chalk.blue('[options]') + ' tasks';
-
-var parser = yargs.usage(usage, cliOptions);
-var opts = parser.argv;
 
 // This translates the --continue flag in gulp
 // To the settle env variable for undertaker
@@ -83,11 +88,6 @@ module.exports = run;
 
 // The actual logic
 function handleArguments(env) {
-  if (opts.help) {
-    console.log(parser.help());
-    exit(0);
-  }
-
   if (opts.version) {
     log.info('CLI version', cliVersion);
     if (env.modulePackage && typeof env.modulePackage.version !== 'undefined') {

--- a/lib/shared/cliOptions.js
+++ b/lib/shared/cliOptions.js
@@ -31,7 +31,8 @@ module.exports = [
   {
     name: 'depth',
     description: 'Specify the depth of the task dependency tree',
-    default: 0
+    pre: 0,
+    init: parseInt
   },
   {
     name: 'tasks-simple',

--- a/lib/shared/cliOptions.js
+++ b/lib/shared/cliOptions.js
@@ -1,98 +1,69 @@
 'use strict';
 
-var chalk = require('chalk');
-
-module.exports = {
-  help: {
-    alias: 'h',
-    type: 'boolean',
-    desc: chalk.gray(
-      'Show this help.'),
+module.exports = [
+  {
+    name: 'version',
+    description: 'Print the global and local gulp versions'
   },
-  version: {
-    alias: 'v',
-    type: 'boolean',
-    desc: chalk.gray(
-      'Print the global and local gulp versions.'),
+  {
+    name: 'require',
+    description: 'Require a module before running the gulpfile'
   },
-  require: {
-    type: 'string',
-    requiresArg: true,
-    desc: chalk.gray(
-      'Will require a module before running the gulpfile. ' +
-      'This is useful for transpilers but also has other applications.'),
+  {
+    name: 'gulpfile',
+    description: 'The path of the gulpfile'
   },
-  gulpfile: {
-    type: 'string',
-    requiresArg: true,
-    desc: chalk.gray(
-      'Manually set path of gulpfile. Useful if you have multiple gulpfiles. ' +
-      'This will set the CWD to the gulpfile directory as well.'),
+  {
+    name: 'cwd',
+    short: 'w',
+    description: 'The current working directory'
   },
-  cwd: {
-    type: 'string',
-    requiresArg: true,
-    desc: chalk.gray(
-      'Manually set the CWD. The search for the gulpfile, ' +
-      'as well as the relativity of all requires will be from here.'),
+  {
+    name: 'verify',
+    short: '-V',
+    description: 'Verify plugins in package.json against their blacklists'
   },
-  verify: {
-    desc: chalk.gray(
-      'Will verify plugins referenced in project\'s package.json against ' +
-      'the plugins blacklist.'),
+  {
+    name: 'tasks',
+    short: 'T',
+    description: 'Display the task dependency tree'
   },
-  tasks: {
-    alias: 'T',
-    type: 'boolean',
-    desc: chalk.gray(
-      'Print the task dependency tree for the loaded gulpfile.'),
+  {
+    name: 'depth',
+    description: 'Specify the depth of the task dependency tree',
+    default: 0
   },
-  depth: {
-    type: 'number',
-    requiresArg: true,
-    desc: chalk.gray(
-      'Specify the depth of the task dependency tree.'),
+  {
+    name: 'tasks-simple',
+    short: 'S',
+    description: 'Display a plaintext list of all tasks'
   },
-  'tasks-simple': {
-    type: 'boolean',
-    desc: chalk.gray(
-      'Print a plaintext list of tasks for the loaded gulpfile.'),
+  {
+    name: 'tasks-json',
+    short: 'J',
+    description: 'Display a JSON list of all tasks'
   },
-  'tasks-json': {
-    desc: chalk.gray(
-      'Print the task dependency tree, ' +
-      'in JSON format, for the loaded gulpfile.'),
+  {
+    name: 'color',
+    description: 'Display colors even if no color support is detected'
   },
-  color: {
-    type: 'boolean',
-    desc: chalk.gray(
-      'Will force gulp and gulp plugins to display colors, ' +
-      'even when no color support is detected.'),
+  {
+    name: 'no-color',
+    description: 'Force gulp and plugins to not display colors'
   },
-  'no-color': {
-    type: 'boolean',
-    desc: chalk.gray(
-      'Will force gulp and gulp plugins to not display colors, ' +
-      'even when color support is detected.'),
+  {
+    name: 'silent',
+    description: 'Disable all gulp logging'
   },
-  silent: {
-    alias: 'S',
-    type: 'boolean',
-    desc: chalk.gray(
-      'Suppress all gulp logging.'),
+  {
+    name: 'continue',
+    short: 'u',
+    description: 'Continue execution of tasks upon failure'
   },
-  continue: {
-    type: 'boolean',
-    desc: chalk.gray(
-      'Continue execution of tasks upon failure.'),
-  },
-  'log-level': {
-    alias: 'L',
-    // Type isn't needed because count acts as a boolean
-    count: true,
-    // Can't use `default` because it seems to be off by one
-    desc: chalk.gray(
-      'Set the loglevel. -L for least verbose and -LLLL for most verbose. ' +
-      '-LLL is default.'),
-  },
-};
+  {
+    name: 'log-level',
+    short: 'L',
+    description: 'Set the loglevel (-L for least verbose and' +
+    '-LLLL for most verbose. -LLL is default)'
+  }
+];

--- a/lib/shared/cliOptions.js
+++ b/lib/shared/cliOptions.js
@@ -63,7 +63,7 @@ module.exports = [
   {
     name: 'log-level',
     short: 'L',
-    description: 'Set the loglevel (-L for least verbose and' +
-    '-LLLL for most verbose. -LLL is default)'
+    description: 'The loglevel: -L for least verbose, -LLLL ' +
+    'for most verbose (-LLL is default)'
   }
 ];

--- a/lib/shared/cliOptions.js
+++ b/lib/shared/cliOptions.js
@@ -20,7 +20,7 @@ module.exports = [
   },
   {
     name: 'verify',
-    short: '-V',
+    short: 'V',
     description: 'Verify plugins in package.json against their blacklists'
   },
   {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "man": "gulp.1",
   "engines": {
-    "node": ">= 0.10"
+    "node": ">= 4.0.0"
   },
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "archy": "^1.0.0",
+    "args": "^1.1.0",
     "chalk": "^1.1.0",
     "fancy-log": "^1.1.0",
     "gulplog": "^1.0.0",


### PR DESCRIPTION
After taking a look on the current implementation of the auto-generated usage information and some other things related to command line arguments within gulp-cli, I've decided that it might be a good idea to set up a real, awesome usage information by adding support for [args](https://github.com/leo/args).

A nice side-effect of this whole PR is that the code is a lot cleaner than before because args is doing a lot of abstraction on top of minimist (not like yargs does it). Here's an example:

<img width="857" alt="screen shot 2016-06-09 at 17 05 12" src="https://cloud.githubusercontent.com/assets/6170607/15934665/b34f2404-2e64-11e6-83a7-14aca0e4321b.png">

As you can see, there's also a tiny bug at the end of the outputted usage information. I have no idea where it comes from and I've already spent hours on searching args for that error, but it looks like there's something within gulp-cli that simply cuts of the output. Maybe someone in here has an idea?