### PR TITLE
Build: make sure to test all callback args

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,8 +15,6 @@ environment:
     - nodejs_version: "6"
 
 install:
-  - npm -g install npm@latest
-  - set PATH=%APPDATA%\npm;%PATH%
   - ps: Install-Product node $env:nodejs_version
   - npm install
 

--- a/test/completion.js
+++ b/test/completion.js
@@ -16,7 +16,9 @@ describe('flag: --completion', function() {
         .gulp('--completion=' + type)
         .run(cb);
 
-      function cb(err, stdout) {
+      function cb(err, stdout, stderr) {
+        expect(err).toNotExist();
+        expect(stderr).toEqual('');
         expect(stdout).toEqual(expected);
         done(err);
       }
@@ -31,8 +33,9 @@ describe('flag: --completion', function() {
       .gulp('--completion=unknown')
       .run(cb);
 
-    function cb(err, stdout) {
-      expect(err).toExist();
+    function cb(err, stdout, stderr) {
+      expect(err).toNotEqual(null);
+      expect(stderr).toEqual('');
       expect(stdout).toEqual(expected);
       done();
     }
@@ -44,7 +47,9 @@ describe('flag: --completion', function() {
       .run(cb);
 
     function cb(err, stdout, stderr) {
+      expect(err).toNotEqual(null);
       expect(stderr).toMatch('Missing completion type');
+      expect(stdout).toEqual('');
       done();
     }
   });

--- a/test/config-description.js
+++ b/test/config-description.js
@@ -20,7 +20,9 @@ describe('config: description', function() {
       .gulp('--tasks')
       .run(cb);
 
-    function cb(err, stdout) {
+    function cb(err, stdout, stderr) {
+      expect(err).toEqual(null);
+      expect(stderr).toEqual('');
       var expected = fs.readFileSync(path.join(expectedDir, 'output0.txt'),
         'utf-8');
       stdout = eraseTime(stdout);
@@ -36,7 +38,9 @@ describe('config: description', function() {
       .gulp('--tasks')
       .run(cb);
 
-    function cb(err, stdout) {
+    function cb(err, stdout, stderr) {
+      expect(err).toEqual(null);
+      expect(stderr).toEqual('');
       var expected = fs.readFileSync(path.join(expectedDir, 'output0.txt'),
         'utf-8');
       stdout = eraseTime(skipLines(stdout, 1));
@@ -52,7 +56,9 @@ describe('config: description', function() {
       .gulp('--tasks', '--gulpfile ../foo/bar/gulpfile.js', '--cwd .')
       .run(cb);
 
-    function cb(err, stdout) {
+    function cb(err, stdout, stderr) {
+      expect(err).toEqual(null);
+      expect(stderr).toEqual('');
       var expected = fs.readFileSync(path.join(expectedDir, 'output1.txt'),
         'utf-8');
       stdout = eraseTime(stdout);

--- a/test/config-flags-gulpfile.js
+++ b/test/config-flags-gulpfile.js
@@ -17,6 +17,8 @@ describe('config: flags.gulpfile', function() {
       .run(cb);
 
     function cb(err, stdout, stderr) {
+      expect(err).toEqual(null);
+      expect(stderr).toEqual('');
       stdout = headLines(stdout, 2, 2);
       expect(stdout).toEqual(
         'This gulpfile : ' +
@@ -24,7 +26,6 @@ describe('config: flags.gulpfile', function() {
           '\n' +
         'The current directory : ' + path.join(fixturesDir, 'flags/gulpfile')
       );
-      expect(stderr).toEqual('');
       done(err);
     }
   });
@@ -36,6 +37,8 @@ describe('config: flags.gulpfile', function() {
       .run(cb);
 
     function cb(err, stdout, stderr) {
+      expect(err).toEqual(null);
+      expect(stderr).toEqual('');
       stdout = headLines(stdout, 2, 3);
       expect(stdout).toEqual(
         'This gulpfile : ' +
@@ -43,7 +46,6 @@ describe('config: flags.gulpfile', function() {
           '\n' +
         'The current directory : ' + path.join(fixturesDir, 'flags/gulpfile')
       );
-      expect(stderr).toEqual('');
       done(err);
     }
   });
@@ -56,12 +58,13 @@ describe('config: flags.gulpfile', function() {
       .run(cb);
 
     function cb(err, stdout, stderr) {
+      expect(err).toEqual(null);
+      expect(stderr).toEqual('');
       stdout = headLines(stdout, 1, 3);
       expect(stdout).toEqual(
         'Another gulpfile : ' +
           path.join(fixturesDir, 'flags/gulpfile/cwd/gulpfile.js')
       );
-      expect(stderr).toEqual('');
       done(err);
     }
   });
@@ -74,12 +77,13 @@ describe('config: flags.gulpfile', function() {
       .run(cb);
 
     function cb(err, stdout, stderr) {
+      expect(err).toEqual(null);
+      expect(stderr).toEqual('');
       stdout = headLines(stdout, 1, 3);
       expect(stdout).toEqual(
         'Another gulpfile : ' +
           path.join(fixturesDir, 'flags/gulpfile/cwd/gulpfile.js')
       );
-      expect(stderr).toEqual('');
       done(err);
     }
   });

--- a/test/config-flags-silent.js
+++ b/test/config-flags-silent.js
@@ -19,8 +19,9 @@ describe('config: flags.silent', function() {
       .run(cb);
 
     function cb(err, stdout, stderr) {
-      expect(stdout).toEqual('');
+      expect(err).toEqual(null);
       expect(stderr).toEqual('');
+      expect(stdout).toEqual('');
       done(err);
     }
   });
@@ -33,13 +34,14 @@ describe('config: flags.silent', function() {
       .run(cb);
 
     function cb(err, stdout, stderr) {
+      expect(err).toEqual(null);
+      expect(stderr).toEqual('');
       stdout = eraseLapse(eraseTime(skipLines(stdout, 1)));
       expect(stdout).toEqual(
         'Starting \'default\'...\n' +
         'Finished \'default\' after ?\n' +
         ''
       );
-      expect(stderr).toEqual('');
       done(err);
     }
   });

--- a/test/exports-as-tasks.js
+++ b/test/exports-as-tasks.js
@@ -19,9 +19,10 @@ describe('exports as tasks', function() {
         '--gulpfile ./test/fixtures/gulpfiles/gulpfile-exports.babel.js')
       .run(cb);
 
-    function cb(err, stdout) {
+    function cb(err, stdout, stderr) {
       var filepath = path.join(expectedDir, 'tasks-as-exports.txt');
       var expected = fs.readFileSync(filepath, 'utf-8');
+      expect(stderr).toEqual('');
       stdout = eraseTime(skipLines(stdout, 2));
       expect(stdout).toEqual(expected);
       done();

--- a/test/flags-continue.js
+++ b/test/flags-continue.js
@@ -16,7 +16,6 @@ describe('flag: --continue', function() {
 
     function cb(err, stdout, stderr) {
       expect(err).toNotEqual(null);
-
       stdout = eraseLapse(eraseTime(skipLines(stdout, 2)));
       expect(stdout).toEqual(
         'Starting \'test4\'...\n' +
@@ -42,7 +41,6 @@ describe('flag: --continue', function() {
 
     function cb(err, stdout, stderr) {
       expect(err).toNotEqual(null);
-
       expect(stdout).toNotMatch('Starting \'anon\'');
       stdout = eraseLapse(eraseTime(skipLines(stdout, 2)));
       expect(stdout).toEqual(

--- a/test/flags-gulpfile.js
+++ b/test/flags-gulpfile.js
@@ -17,7 +17,10 @@ describe('flag: --gulpfile', function() {
       .gulp('--gulpfile', gulpfilePath)
       .run(cb);
 
-    function cb(err, stdout) {
+    function cb(err, stdout, stderr) {
+      expect(err).toEqual(null);
+      expect(stderr).toEqual('');
+
       var chgWorkdirLog = headLines(stdout, 1);
       var workdir = path.dirname(gulpfilePath).replace(/\//g, path.sep);
       expect(chgWorkdirLog).toMatch('Working directory changed to ');

--- a/test/flags-help.js
+++ b/test/flags-help.js
@@ -21,7 +21,9 @@ describe('flag: --help', function() {
       .gulp('--help', '--cwd ./test/fixtures/gulpfiles')
       .run(cb);
 
-    function cb(err, stdout) {
+    function cb(err, stdout, stderr) {
+      expect(err).toEqual(null);
+      expect(stderr).toEqual('');
       stdout = eraseFirstSpace(stdout);
       expect(stdout).toEqual(outputText);
       done(err);
@@ -33,7 +35,9 @@ describe('flag: --help', function() {
       .gulp('--h', '--cwd ./test/fixtures/gulpfiles')
       .run(cb);
 
-    function cb(err, stdout) {
+    function cb(err, stdout, stderr) {
+      expect(err).toEqual(null);
+      expect(stderr).toEqual('');
       stdout = eraseFirstSpace(stdout);
       expect(stdout).toEqual(outputText);
       done(err);

--- a/test/flags-require.js
+++ b/test/flags-require.js
@@ -15,7 +15,9 @@ describe('flag: --require', function() {
       .gulp('--require ../test-module.js', '--cwd ./test/fixtures/gulpfiles')
       .run(cb);
 
-    function cb(err, stdout) {
+    function cb(err, stdout, stderr) {
+      expect(err).toEqual(null);
+      expect(stderr).toEqual('');
       var insideLog = headLines(stdout, 1);
       expect(insideLog).toEqual('inside test module');
 
@@ -54,6 +56,9 @@ describe('flag: --require', function() {
       .run(cb);
 
     function cb(err, stdout, stderr) {
+      expect(err).toEqual(null);
+      stderr = eraseLapse(eraseTime(stderr));
+      expect(stderr).toMatch('Failed to load external module ./null-module.js');
       expect(stdout).toNotMatch('inside test module');
       expect(stdout).toNotMatch(
         'Requiring external module ../test-module.js');

--- a/test/flags-silent.js
+++ b/test/flags-silent.js
@@ -10,7 +10,9 @@ describe('flag: --silent', function() {
       .gulp('--silent', '--cwd ./test/fixtures/gulpfiles')
       .run(cb);
 
-    function cb(err, stdout) {
+    function cb(err, stdout, stderr) {
+      expect(err).toEqual(null);
+      expect(stderr).toEqual('');
       expect(stdout).toEqual('');
       done(err);
     }

--- a/test/flags-tasks-json.js
+++ b/test/flags-tasks-json.js
@@ -15,7 +15,9 @@ describe('flag: --tasks-json', function() {
       .gulp('--tasks-json --gulpfile ./test/fixtures/gulpfiles/gulpfile.js')
       .run(cb);
 
-    function cb(err, stdout) {
+    function cb(err, stdout, stderr) {
+      expect(err).toEqual(null);
+      expect(stderr).toEqual('');
       stdout = skipLines(stdout, 1);
       expect(JSON.parse(stdout)).toEqual(expected);
       done();
@@ -33,7 +35,11 @@ describe('flag: --tasks-json', function() {
           '--gulpfile ./test/fixtures/gulpfiles/gulpfile.js')
         .run(cb);
 
-      function cb(err) {
+      function cb(err, stdout, stderr) {
+        expect(err).toEqual(null);
+        expect(stderr).toEqual('');
+        stdout = skipLines(stdout, 1);
+        expect(stdout).toEqual('');
         var file = fs.readFileSync(__dirname + '/output/tasks.json', 'utf8');
         var parsedJson = JSON.parse(file);
         expect(parsedJson).toEqual(expected);

--- a/test/flags-tasks-simple.js
+++ b/test/flags-tasks-simple.js
@@ -15,7 +15,9 @@ describe('flag: --tasks-simple', function() {
       .gulp('--tasks-simple', '--cwd ./test/fixtures/gulpfiles')
       .run(cb);
 
-    function cb(err, stdout) {
+    function cb(err, stdout, stderr) {
+      expect(err).toEqual(null);
+      expect(stderr).toEqual('');
       expect(stdout).toEqual(outputText);
       done(err);
     }

--- a/test/flags-tasks.js
+++ b/test/flags-tasks.js
@@ -16,7 +16,9 @@ describe('flag: --tasks', function() {
       .gulp('--tasks --cwd ./test/fixtures/gulpfiles')
       .run(cb);
 
-    function cb(err, stdout) {
+    function cb(err, stdout, stderr) {
+      expect(err).toEqual(null);
+      expect(stderr).toEqual('');
       var filepath = path.join(expectedDir, 'flags-tasks.txt');
       var expected = fs.readFileSync(filepath, 'utf-8');
       stdout = eraseTime(skipLines(stdout, 1));
@@ -32,7 +34,9 @@ describe('flag: --tasks', function() {
         '--cwd ./test/fixtures')
       .run(cb);
 
-    function cb(err, stdout) {
+    function cb(err, stdout, stderr) {
+      expect(err).toEqual(null);
+      expect(stderr).toEqual('');
       var filepath = path.join(expectedDir, 'with-desc-and-flags.txt');
       var expected = fs.readFileSync(filepath, 'utf-8');
       stdout = eraseTime(skipLines(stdout, 1));
@@ -49,7 +53,9 @@ describe('flag: --tasks', function() {
         '--cwd ./test/fixtures')
       .run(cb);
 
-    function cb(err, stdout) {
+    function cb(err, stdout, stderr) {
+      expect(err).toEqual(null);
+      expect(stderr).toEqual('');
       var filepath = path.join(expectedDir, 'by-unwrap-and-not-by-unwrap.txt');
       var expected = fs.readFileSync(filepath, 'utf-8');
       stdout = eraseTime(skipLines(stdout, 1));

--- a/test/flags-verify.js
+++ b/test/flags-verify.js
@@ -12,9 +12,9 @@ describe('flag: --verify', function() {
       .gulp('--verify invalid-package.json', '--cwd ./test/fixtures/packages/')
       .run(cb);
 
-    function cb(err, stdout) {
+    function cb(err, stdout, stderr) {
       expect(err).toNotEqual(null);
-
+      expect(stderr).toEqual('');
       stdout = eraseTime(stdout);
       expect(stdout).toEqual(
         'Verifying plugins in ' +
@@ -33,7 +33,9 @@ describe('flag: --verify', function() {
       .gulp('--verify valid-package.json', '--cwd ./test/fixtures/packages/')
       .run(cb);
 
-    function cb(err, stdout) {
+    function cb(err, stdout, stderr) {
+      expect(err).toEqual(null);
+      expect(stderr).toEqual('');
       stdout = eraseTime(stdout);
       expect(stdout).toEqual(
         'Verifying plugins in ' +
@@ -51,9 +53,9 @@ describe('flag: --verify', function() {
       .gulp('--verify', '--cwd ./test/fixtures/packages/')
       .run(cb);
 
-    function cb(err, stdout) {
+    function cb(err, stdout, stderr) {
       expect(err).toNotEqual(null);
-
+      expect(stderr).toEqual('');
       stdout = eraseTime(stdout);
       expect(stdout).toEqual(
         'Verifying plugins in ' +

--- a/test/flags-version.js
+++ b/test/flags-version.js
@@ -14,7 +14,8 @@ describe('flag: --version', function() {
       .gulp('--version --cwd ./test/fixtures/gulpfiles')
       .run(cb);
 
-    function cb(err, stdout) {
+    function cb(err, stdout, stderr) {
+      expect(stderr).toEqual('');
       stdout = eraseTime(stdout);
       expect(stdout).toEqual(
         'CLI version ' + cliVersion + '\n' +

--- a/test/logging.js
+++ b/test/logging.js
@@ -9,11 +9,12 @@ describe('logging', function() {
     child.exec('node ' + __dirname + '/fixtures/logging.js -LLLL', cb);
 
     function cb(err, stdout, stderr) {
+      expect(err).toEqual(null);
+      expect(stderr).toMatch('test error');
       stdout = stdout.replace(/\\/g, '/').split('\n');
       expect(stdout[0]).toMatch('test debug');
       expect(stdout[1]).toMatch('test info');
       expect(stdout[2]).toMatch('test warn');
-      expect(stderr).toMatch('test error');
       done(err);
     }
   });
@@ -22,10 +23,11 @@ describe('logging', function() {
     child.exec('node ' + __dirname + '/fixtures/logging.js', cb);
 
     function cb(err, stdout, stderr) {
+      expect(err).toEqual(null);
+      expect(stderr).toMatch('test error');
       stdout = stdout.replace(/\\/g, '/').split('\n');
       expect(stdout[0]).toMatch('test info');
       expect(stdout[1]).toMatch('test warn');
-      expect(stderr).toMatch('test error');
       done(err);
     }
   });
@@ -34,10 +36,11 @@ describe('logging', function() {
     child.exec('node ' + __dirname + '/fixtures/logging.js -LLL', cb);
 
     function cb(err, stdout, stderr) {
+      expect(err).toEqual(null);
+      expect(stderr).toMatch('test error');
       stdout = stdout.replace(/\\/g, '/').split('\n');
       expect(stdout[0]).toMatch('test info');
       expect(stdout[1]).toMatch('test warn');
-      expect(stderr).toMatch('test error');
       done(err);
     }
   });
@@ -46,9 +49,10 @@ describe('logging', function() {
     child.exec('node ' + __dirname + '/fixtures/logging.js -LL', cb);
 
     function cb(err, stdout, stderr) {
+      expect(err).toEqual(null);
+      expect(stderr).toMatch('test error');
       stdout = stdout.replace(/\\/g, '/').split('\n');
       expect(stdout[0]).toMatch('test warn');
-      expect(stderr).toMatch('test error');
       done(err);
     }
   });
@@ -57,7 +61,9 @@ describe('logging', function() {
     child.exec('node ' + __dirname + '/fixtures/logging.js -L', cb);
 
     function cb(err, stdout, stderr) {
+      expect(err).toEqual(null);
       expect(stderr).toMatch('test error');
+      expect(stdout).toEqual('');
       done(err);
     }
   });


### PR DESCRIPTION
Playing around with an idea (not sure yet if I want to submit that) I found it convenient to always assert the outputs of all the streams, this helps narrow things down quickly when tests fail.

Note: If you guys agree with this principle, I guess the open PRs https://github.com/gulpjs/gulp-cli/pull/75 and https://github.com/gulpjs/gulp-cli/pull/113 might have to be amended accordingly. Let me know if I can help out.