### PR TITLE
Fix: Blacklist redirect

### DIFF
--- a/lib/shared/getBlacklist.js
+++ b/lib/shared/getBlacklist.js
@@ -2,7 +2,7 @@
 
 var wreck = require('wreck');
 
-var url = 'http://gulpjs.com/plugins/blackList.json';
+var url = 'https://gulpjs.com/plugins/blackList.json';
 
 function getBlacklist(cb) {
   wreck.get(url, { json: true }, function(err, res, blacklist) {


### PR DESCRIPTION
Several tests were failing for me [here](https://travis-ci.org/erikkemperman/gulp-cli/builds/260972095?utm_source=github_status&utm_medium=notification), while the exact same code on [gulp/master](https://travis-ci.org/gulpjs/gulp-cli/builds/242142880?utm_source=github_status&utm_medium=notification) was somehow fine.

Superficially the errors seemed to be about flags, such as loglevel... But it was something else entirely.

Turns out an external change sabotaged a bunch of our tests here, viz. we now get a "moved permanently"  (301) when fetching the blacklist, and apparently the wreck library doesn't follow redirects (by default).

I fixed the URL in this PR, perhaps the wreck options should be revisited some time.

This was pretty annoying to track down... The tests are already slightly tricky to debug because stdout and stderr are hijacked. But it becomes really problematic if a unit test depends on unrelated components, both internal (in this case, the getBlacklist module) and external (the corresponding webserver).

IMHO, it should not be possible for this kind of external change to break unit tests?