### PR TITLE
Update: Bump some dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,8 @@ var usage =
   '\n' + chalk.bold('Usage:') +
   ' gulp ' + chalk.blue('[options]') + ' tasks';
 
-var parser = yargs.usage(usage, cliOptions);
+var parser = yargs.usage(usage, cliOptions)
+                  .help('help', cliOptions.help.desc);
 var opts = parser.argv;
 
 // Set up event listeners for logging temporarily.
@@ -105,11 +106,6 @@ function handleArguments(env) {
 
   // Set up event listeners for logging again after configuring.
   toConsole(log, opts);
-
-  if (opts.help) {
-    console.log(parser.help());
-    exit(0);
-  }
 
   if (opts.version) {
     log.info('CLI version', cliVersion);

--- a/lib/shared/config/env-flags.js
+++ b/lib/shared/config/env-flags.js
@@ -12,11 +12,11 @@ function mergeConfigToEnvFlags(env, config) {
   return copyProps(env, config, toFrom, convert, true);
 }
 
-function convert(value, configKey, envKey) {
-  if (envKey === 'configBase') {
-    return path.dirname(value);
+function convert(srcInfo, dstInfo) {
+  if (dstInfo.keyChain === 'configBase') {
+    return path.dirname(srcInfo.value);
   }
-  return value;
+  return srcInfo.value;
 }
 
 module.exports = mergeConfigToEnvFlags;

--- a/lib/shared/config/load-files.js
+++ b/lib/shared/config/load-files.js
@@ -16,11 +16,11 @@ function loadConfigFiles(configFiles, configFileOrder) {
 
     copyProps(require(filePath), config, convert);
 
-    function convert(value, name) {
-      if (name === 'flags.gulpfile') {
-        return path.resolve(path.dirname(filePath), value);
+    function convert(srcInfo) {
+      if (srcInfo.keyChain === 'flags.gulpfile') {
+        return path.resolve(path.dirname(filePath), srcInfo.value);
       }
-      return value;
+      return srcInfo.value;
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "jscs-preset-gulp": "^1.0.0",
     "marked-man": "^0.1.3",
     "mocha": "^3.2.0",
-    "nyc": "^10.0.0"
+    "nyc": "^11.1.0"
   },
   "keywords": [
     "build",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "pretty-hrtime": "^1.0.0",
     "semver-greatest-satisfied-range": "^1.0.0",
     "tildify": "^1.0.0",
-    "v8flags": "^2.0.9",
+    "v8flags": "^3.0.0",
     "wreck": "^6.3.0",
     "yargs": "^3.28.0"
   },

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "eslint": "^1.7.3",
     "eslint-config-gulp": "^2.0.0",
     "expect": "^1.20.2",
-    "fs-extra": "^0.26.1",
+    "fs-extra": "~2.0.0",
     "github-changes": "^1.0.1",
     "gulp": "gulpjs/gulp#4.0",
     "gulp-test-tools": "^0.6.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "tildify": "^1.0.0",
     "v8flags": "^3.0.0",
     "wreck": "^6.3.0",
-    "yargs": "^3.28.0"
+    "yargs": "^7.1.0"
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "babel-preset-es2015": "^6.5.0",
     "babel-register": "^6.5.1",
-    "coveralls": "^2.7.0",
+    "coveralls": "2.11.15",
     "eslint": "^1.7.3",
     "eslint-config-gulp": "^2.0.0",
     "expect": "^1.20.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "archy": "^1.0.0",
-    "chalk": "^1.1.0",
+    "chalk": "^1.1.3",
     "copy-props": "^2.0.1",
     "fancy-log": "^1.1.0",
     "gulplog": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "archy": "^1.0.0",
     "chalk": "^1.1.0",
-    "copy-props": "^1.4.1",
+    "copy-props": "^2.0.1",
     "fancy-log": "^1.1.0",
     "gulplog": "^1.0.0",
     "interpret": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "github-changes": "^1.0.1",
     "gulp": "gulpjs/gulp#4.0",
     "gulp-test-tools": "^0.6.1",
-    "jscs": "^2.3.5",
+    "jscs": "^3.0.7",
     "jscs-preset-gulp": "^1.0.0",
     "marked-man": "^0.1.3",
     "mocha": "^3.2.0",

--- a/test/expected/flags-help.txt
+++ b/test/expected/flags-help.txt
@@ -2,21 +2,35 @@
 Usage: gulp [options] tasks
 
 Options:
-  --help, -h              Show this help.  [boolean]
-  --version, -v           Print the global and local gulp versions.  [boolean]
-  --require               Will require a module before running the gulpfile. This is useful for transpilers but also has other applications.  [string]
-  --gulpfile              Manually set path of gulpfile. Useful if you have multiple gulpfiles. This will set the CWD to the gulpfile directory as well.  [string]
-  --cwd                   Manually set the CWD. The search for the gulpfile, as well as the relativity of all requires will be from here.  [string]
-  --verify                Will verify plugins referenced in project's package.json against the plugins blacklist.
-  --tasks, -T             Print the task dependency tree for the loaded gulpfile.  [boolean]
-  --tasks-simple          Print a plaintext list of tasks for the loaded gulpfile.  [boolean]
-  --tasks-json            Print the task dependency tree, in JSON format, for the loaded gulpfile.
-  --tasks-depth, --depth  Specify the depth of the task dependency tree.
-  --compact-tasks         Reduce the output of task dependency tree by printing only top tasks and their child tasks.  [boolean]
-  --sort-tasks            Will sort top tasks of task dependency tree.  [boolean]
-  --color                 Will force gulp and gulp plugins to display colors, even when no color support is detected.  [boolean]
-  --no-color              Will force gulp and gulp plugins to not display colors, even when color support is detected.  [boolean]
-  --silent, -S            Suppress all gulp logging.  [boolean]
-  --continue              Continue execution of tasks upon failure.  [boolean]
-  --log-level, -L         Set the loglevel. -L for least verbose and -LLLL for most verbose. -LLL is default.  [count]
+  --help, -h              Show this help.                              [boolean]
+  --version, -v           Print the global and local gulp versions.    [boolean]
+  --require               Will require a module before running the gulpfile.
+                          This is useful for transpilers but also has other
+                          applications.                                 [string]
+  --gulpfile              Manually set path of gulpfile. Useful if you have
+                          multiple gulpfiles. This will set the CWD to the
+                          gulpfile directory as well.                   [string]
+  --cwd                   Manually set the CWD. The search for the gulpfile, as
+                          well as the relativity of all requires will be from
+                          here.                                         [string]
+  --verify                Will verify plugins referenced in project's
+                          package.json against the plugins blacklist.
+  --tasks, -T             Print the task dependency tree for the loaded
+                          gulpfile.                                    [boolean]
+  --tasks-simple          Print a plaintext list of tasks for the loaded
+                          gulpfile.                                    [boolean]
+  --tasks-json            Print the task dependency tree, in JSON format, for
+                          the loaded gulpfile.
+  --tasks-depth, --depth  Specify the depth of the task dependency tree.[number]
+  --compact-tasks         Reduce the output of task dependency tree by printing
+                          only top tasks and their child tasks.        [boolean]
+  --sort-tasks            Will sort top tasks of task dependency tree. [boolean]
+  --color                 Will force gulp and gulp plugins to display colors,
+                          even when no color support is detected.      [boolean]
+  --no-color              Will force gulp and gulp plugins to not display
+                          colors, even when color support is detected. [boolean]
+  --silent, -S            Suppress all gulp logging.                   [boolean]
+  --continue              Continue execution of tasks upon failure.    [boolean]
+  --log-level, -L         Set the loglevel. -L for least verbose and -LLLL for
+                          most verbose. -LLL is default.                 [count]
 


### PR DESCRIPTION
I was about to go through all the gulpjs repos with a minor line-ending tweak in response to https://github.com/gulpjs/vinyl-fs/pull/269, when I figured I might as well do some other dreary menial work whilst traversing the repos anyway. So here are a bunch of more or less trivial dependency bumps. 

Feel free to squash these commits if you like, but thought I'd submit them separately so you could cherry-pick if you wanted.

Note especially the dependencies whose recent releases won't work with Node 0.10/0.12:

- chalk, last usable version is 1.1.3
- wreck, last usable version is 6.3.0
- yargs, last usable version is 7.1.0
- coveralls, last usable version is 2.11.15 (note, coveralls 2.11.16 does _not_ work due to transitive dependency on request 2.77.0)
- fs-extra, last usable version is 2.0.0 (note, 2.1.0 does _not_ work due to `const` keywords)
- eslint, last usable version is 2.* but I did not bump it here, pending these being resolved:
https://github.com/gulpjs/eslint-config-gulp/pull/13
https://github.com/gulpjs/eslint-config-gulp/issues/8

Also, is `github-changes` actually being used? I don't see it in other repos (the ones I checked so far, anyway) and it's pulling in a bunch of ancient modules (like lodash 2).