### PR TITLE
Update: -f alias for --gulpfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ __Some flags only work with gulp 4 and will be ignored when invoked against gulp
     </tr>
     <tr>
       <td>--gulpfile [path]</td>
-      <td></td>
+      <td>-f</td>
       <td>Manually set path of gulpfile. Useful if you have multiple gulpfiles. This will set the CWD to the gulpfile directory as well.</td>
     </tr>
     <tr>

--- a/lib/shared/cliOptions.js
+++ b/lib/shared/cliOptions.js
@@ -23,6 +23,7 @@ module.exports = {
       'This is useful for transpilers but also has other applications.'),
   },
   gulpfile: {
+    alias: 'f',
     type: 'string',
     requiresArg: true,
     desc: chalk.gray(

--- a/test/expected/flags-help.txt
+++ b/test/expected/flags-help.txt
@@ -5,7 +5,7 @@ Options:
   --help, -h              Show this help.  [boolean]
   --version, -v           Print the global and local gulp versions.  [boolean]
   --require               Will require a module before running the gulpfile. This is useful for transpilers but also has other applications.  [string]
-  --gulpfile              Manually set path of gulpfile. Useful if you have multiple gulpfiles. This will set the CWD to the gulpfile directory as well.  [string]
+  --gulpfile, -f          Manually set path of gulpfile. Useful if you have multiple gulpfiles. This will set the CWD to the gulpfile directory as well.  [string]
   --cwd                   Manually set the CWD. The search for the gulpfile, as well as the relativity of all requires will be from here.  [string]
   --verify                Will verify plugins referenced in project's package.json against the plugins blacklist.
   --tasks, -T             Print the task dependency tree for the loaded gulpfile.  [boolean]

--- a/test/flags-gulpfile.js
+++ b/test/flags-gulpfile.js
@@ -10,11 +10,40 @@ var path = require('path');
 
 describe('flag: --gulpfile', function() {
 
-  it('Manually set path of gulpfile', function(done) {
+  it('Manually set path of gulpfile using --gulpfile', function(done) {
     var gulpfilePath = 'test/fixtures/gulpfiles/gulpfile-2.js';
 
     runner({ verbose: false })
       .gulp('--gulpfile', gulpfilePath)
+      .run(cb);
+
+    function cb(err, stdout, stderr) {
+      expect(err).toEqual(null);
+      expect(stderr).toEqual('');
+
+      var chgWorkdirLog = headLines(stdout, 1);
+      var workdir = path.dirname(gulpfilePath).replace(/\//g, path.sep);
+      expect(chgWorkdirLog).toMatch('Working directory changed to ');
+      expect(chgWorkdirLog).toMatch(workdir);
+
+      stdout = eraseLapse(eraseTime(skipLines(stdout, 2)));
+      expect(stdout).toEqual(
+        'Starting \'default\'...\n' +
+        'Starting \'logGulpfilePath\'...\n' +
+        path.resolve(gulpfilePath) + '\n' +
+        'Finished \'logGulpfilePath\' after ?\n' +
+        'Finished \'default\' after ?\n' +
+        ''
+      );
+      done(err);
+    }
+  });
+
+  it('Manually set path of gulpfile using -f', function(done) {
+    var gulpfilePath = 'test/fixtures/gulpfiles/gulpfile-2.js';
+
+    runner({ verbose: false })
+      .gulp('-f', gulpfilePath)
       .run(cb);
 
     function cb(err, stdout, stderr) {


### PR DESCRIPTION
I meant to propose this for some time -- I find myself using `--gulpfile` quite often, and would love to be able to use an alias for that flag.

Not sure if there's a policy on this, but `-f` makes sense to me and would mesh nicely with what folks might know from other build tools.