### PR TITLE
Modify the tests about log-level config against timeout on AppVeyor

### DIFF
--- a/test/config-flags-log-level.js
+++ b/test/config-flags-log-level.js
@@ -2,8 +2,12 @@
 
 var expect = require('expect');
 var path = require('path');
+var skipLines = require('gulp-test-tools').skipLines;
 var eraseTime = require('gulp-test-tools').eraseTime;
+var eraseLapse = require('gulp-test-tools').eraseLapse;
 var runner = require('gulp-test-tools').gulpRunner;
+
+var isAppveyor = process.env['APPVEYOR'] === 'True';
 
 describe('config: flag.logLevel', function() {
 
@@ -20,6 +24,11 @@ describe('config: flag.logLevel', function() {
     });
 
     it('Should output warn log', function(done) {
+      if (isAppveyor) {
+        this.skip(); // Because timout frequently
+        return;
+      }
+
       var packageJsonPath = path.resolve(__dirname, 'fixtures/packages',
         'invalid-package.json');
 
@@ -37,16 +46,17 @@ describe('config: flag.logLevel', function() {
     });
 
     it('Should output info log', function(done) {
-      var packageJsonPath = path.resolve(__dirname, 'fixtures/packages',
-        'valid-package.json');
+      var gulpfile = path.resolve(__dirname, 'fixtures/gulpfiles/gulpfile.js');
 
       runner({ verbose: false })
-        .gulp('--verify', packageJsonPath)
+        .gulp('--gulpfile', gulpfile, 'test1')
         .run(function(err, stdout, stderr) {
           expect(err).toEqual(null);
-          expect(eraseTime(stdout)).toEqual(
-            'Verifying plugins in ' + packageJsonPath + '\n' +
-            'There are no blacklisted plugins in this project\n');
+          expect(eraseLapse(eraseTime(skipLines(stdout, 2)))).toEqual(
+            'Starting \'test1\'...\n' +
+            'Starting \'noop\'...\n' +
+            'Finished \'noop\' after ?\n' +
+            'Finished \'test1\' after ?\n');
           expect(stderr).toEqual('');
           done(err);
         });
@@ -68,7 +78,12 @@ describe('config: flag.logLevel', function() {
         });
     });
 
-    it('Should output warn log', function(done) {
+    it('Should not output warn log', function(done) {
+      if (isAppveyor) {
+        this.skip(); // Because timout frequently
+        return;
+      }
+
       var packageJsonPath = path.resolve(__dirname, 'fixtures/packages',
         'invalid-package.json');
 
@@ -81,11 +96,8 @@ describe('config: flag.logLevel', function() {
         });
     });
 
-    it('Should output info log', function(done) {
-      var packageJsonPath = path.resolve(__dirname, 'fixtures/packages',
-        'valid-package.json');
-
-      gulp('--verify', packageJsonPath)
+    it('Should not output info log', function(done) {
+      gulp('test')
         .run(function(err, stdout, stderr) {
           expect(err).toEqual(null);
           expect(stdout).toEqual('');
@@ -111,6 +123,11 @@ describe('config: flag.logLevel', function() {
     });
 
     it('Should output warn log', function(done) {
+      if (isAppveyor) {
+        this.skip(); // Because timout frequently
+        return;
+      }
+
       var packageJsonPath = path.resolve(__dirname, 'fixtures/packages',
         'invalid-package.json');
 
@@ -125,11 +142,8 @@ describe('config: flag.logLevel', function() {
         });
     });
 
-    it('Should output info log', function(done) {
-      var packageJsonPath = path.resolve(__dirname, 'fixtures/packages',
-        'valid-package.json');
-
-      gulp('--verify', packageJsonPath)
+    it('Should not output info log', function(done) {
+      gulp('test')
         .run(function(err, stdout, stderr) {
           expect(err).toEqual(null);
           expect(stdout).toEqual('');
@@ -155,6 +169,11 @@ describe('config: flag.logLevel', function() {
     });
 
     it('Should output warn log', function(done) {
+      if (isAppveyor) {
+        this.skip(); // Because timout frequently
+        return;
+      }
+
       var packageJsonPath = path.resolve(__dirname, 'fixtures/packages',
         'invalid-package.json');
 
@@ -171,15 +190,12 @@ describe('config: flag.logLevel', function() {
     });
 
     it('Should output info log', function(done) {
-      var packageJsonPath = path.resolve(__dirname, 'fixtures/packages',
-        'valid-package.json');
-
-      gulp('--verify', packageJsonPath)
+      gulp('test')
         .run(function(err, stdout, stderr) {
           expect(err).toEqual(null);
-          expect(eraseTime(stdout)).toEqual(
-            'Verifying plugins in ' + packageJsonPath + '\n' +
-            'There are no blacklisted plugins in this project\n');
+          expect(eraseLapse(eraseTime(skipLines(stdout, 1)))).toEqual(
+            'Starting \'test\'...\n' +
+            'Finished \'test\' after ?\n');
           expect(stderr).toEqual('');
           done(err);
         });

--- a/test/fixtures/config/flags/logLevel/L/gulpfile.js
+++ b/test/fixtures/config/flags/logLevel/L/gulpfile.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var gulp = require('gulp');
+
+gulp.task('test', function(cb) {
+  return cb();
+});

--- a/test/fixtures/config/flags/logLevel/LL/gulpfile.js
+++ b/test/fixtures/config/flags/logLevel/LL/gulpfile.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var gulp = require('gulp');
+
+gulp.task('test', function(cb) {
+  return cb();
+});

--- a/test/fixtures/config/flags/logLevel/LLL/gulpfile.js
+++ b/test/fixtures/config/flags/logLevel/LLL/gulpfile.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var gulp = require('gulp');
+
+gulp.task('test', function(cb) {
+  return cb();
+});


### PR DESCRIPTION
The tests about log-level config and verify flag cause timeout errors frequently on Appveyor, because accessing to the remote blacklist file sometimes take too much time.

So I've modified the test cases about log-level config to replace/skip accessing the blacklist file. (Replacing all cases is impossible because `log.warn` is used by only verify flag in gulp-cli).