### PR TITLE
Use meaningful processTitle for better monitoring

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,8 +33,10 @@ var ranges = fs.readdirSync(__dirname + '/lib/versioned/');
 // before anything touches it
 process.env.INIT_CWD = process.cwd();
 
+var cmdArgs = process.argv.slice(2);
 var cli = new Liftoff({
   name: 'gulp',
+  processTitle: ['gulp'].concat(cmdArgs).join(' '),
   completions: completion,
   extensions: interpret.jsVariants,
   v8flags: v8flags,


### PR DESCRIPTION
At the moment when we run several gulp tasks separately, they have the same process title `gulp` which is very hard to differentiate and monitor them. This PR is to solve that issue.