### PR TITLE
Fix: Log requireFail results in yellow on stdout instead of red on stderr (fixes #142)

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ cli.on('require', function(name) {
 });
 
 cli.on('requireFail', function(name) {
-  log.error(ansi.red('Failed to load external module'), ansi.magenta(name));
+  log.warn(ansi.yellow('Failed to load external module'), ansi.magenta(name));
 });
 
 cli.on('respawn', function(flags, child) {

--- a/lib/shared/ansi.js
+++ b/lib/shared/ansi.js
@@ -15,6 +15,7 @@ module.exports = {
   gray: hasColors ? colors.gray : noColor,
   bgred: hasColors ? colors.bgred : noColor,
   bold: hasColors ? colors.bold : noColor,
+  yellow: hasColors ? colors.yellow : noColor,
 };
 
 function noColor(message) {

--- a/test/exports-as-tasks.js
+++ b/test/exports-as-tasks.js
@@ -19,13 +19,13 @@ describe('exports as tasks', function() {
         '--gulpfile ./test/fixtures/gulpfiles/gulpfile-exports.babel.js')
       .run(cb);
 
-    function cb(err, stdout) {
+    function cb(err, stdout, stderr) {
       expect(err).toEqual(null);
-      // Skipping stderr expectation because babel broke node 0.10
-      // expect(stderr).toEqual('');
+      expect(stderr).toEqual('');
       var filepath = path.join(expectedDir, 'tasks-as-exports.txt');
       var expected = fs.readFileSync(filepath, 'utf-8');
-      stdout = eraseTime(skipLines(stdout, 2));
+      // Remove babel/register lines
+      stdout = eraseTime(skipLines(stdout, 3));
       expect(stdout).toEqual(expected);
       done(err);
     }

--- a/test/flags-require.js
+++ b/test/flags-require.js
@@ -50,25 +50,26 @@ describe('flag: --require', function() {
     }
   });
 
-  it('errors if module doesn\'t exist', function(done) {
+  it('warns if module doesn\'t exist', function(done) {
     runner({ verbose: false })
       .gulp('--require ./null-module.js', '--cwd ./test/fixtures/gulpfiles')
       .run(cb);
 
     function cb(err, stdout, stderr) {
       expect(err).toEqual(null);
-      stderr = eraseLapse(eraseTime(stderr));
-      expect(stderr).toMatch('Failed to load external module ./null-module.js');
+      expect(stderr).toEqual('');
+      stdout = eraseLapse(eraseTime(stdout));
+      expect(stdout).toMatch('Failed to load external module ./null-module.js');
       expect(stdout).toNotMatch('inside test module');
       expect(stdout).toNotMatch(
         'Requiring external module ../test-module.js');
 
-      var chgWorkdirLog = headLines(stdout, 1);
+      var chgWorkdirLog = headLines(stdout, 2);
       var workdir = 'test/fixtures/gulpfiles'.replace(/\//g, path.sep);
       expect(chgWorkdirLog).toMatch('Working directory changed to ');
       expect(chgWorkdirLog).toMatch(workdir);
 
-      stdout = eraseLapse(eraseTime(skipLines(stdout, 2)));
+      stdout = eraseLapse(eraseTime(skipLines(stdout, 3)));
       expect(stdout).toEqual(
         'Starting \'default\'...\n' +
          'Starting \'test1\'...\n' +
@@ -85,9 +86,6 @@ describe('flag: --require', function() {
         ''
       );
 
-      stderr = eraseTime(stderr);
-      expect(stderr).toEqual(
-        'Failed to load external module ./null-module.js\n');
       done(err);
     }
   });


### PR DESCRIPTION
@sttk what do you think of this change?  It seems like some tools interpret stderr wrong (like `husky`) and treat any output as a failure.  This change is mostly a cosmetic one but it does change some tests.