### PR TITLE
Tailor message when local gulp is missing

### DIFF
--- a/index.js
+++ b/index.js
@@ -139,11 +139,23 @@ function handleArguments(env) {
   }
 
   if (!env.modulePath) {
+    var missingNodeModules =
+      fs.existsSync(path.join(env.cwd, 'package.json'))
+      && !fs.existsSync(path.join(env.cwd, 'node_modules'));
+
+    var missingGulpMessage =
+      missingNodeModules
+        ? 'Local modules not found in'
+        : 'Local gulp not found in';
     log.error(
-      ansi.red('Local gulp not found in'),
+      ansi.red(missingGulpMessage),
       ansi.magenta(tildify(env.cwd))
     );
-    log.error(ansi.red('Try running: npm install gulp'));
+    var installCommand =
+      missingNodeModules
+        ? 'npm install'
+        : 'npm install gulp';
+    log.error(ansi.red('Try running: ' + installCommand));
     exit(1);
   }
 


### PR DESCRIPTION
When there is a yarn.lock file, show yarn commands instead of npm commands
When there is a package.json file but no node_modules folder, tell them to run
the full install command, instead of just adding gulp