### PR TITLE
Tailor "gulp missing" message when `yarn.lock` file exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,10 +162,15 @@ function handleArguments(env) {
       ansi.red(missingGulpMessage),
       ansi.magenta(tildify(env.cwd))
     );
+    var hasYarn = fs.existsSync(path.join(env.cwd, 'yarn.lock'));
     /* istanbul ignore next */
     var installCommand =
       missingNodeModules
-        ? 'npm install'
+        ? hasYarn
+          ? 'yarn install'
+          : 'npm install'
+        : hasYarn
+          ? 'yarn add gulp'
         : 'npm install gulp';
     log.error(ansi.red('Try running: ' + installCommand));
     exit(1);


### PR DESCRIPTION
This was separated from #155, and builds on top of it