### PR TITLE
replace https with request to allow for proxy configuration

### DIFF
--- a/lib/shared/get-blacklist.js
+++ b/lib/shared/get-blacklist.js
@@ -1,19 +1,8 @@
 'use strict';
 
-var https = require('https');
-
-var concat = require('concat-stream');
+var request = require('request');
 
 var url = 'https://gulpjs.com/plugins/blackList.json';
-
-function collect(stream, cb) {
-  stream.on('error', cb);
-  stream.pipe(concat(onSuccess));
-
-  function onSuccess(result) {
-    cb(null, result);
-  }
-}
 
 function parse(str, cb) {
   try {
@@ -25,25 +14,19 @@ function parse(str, cb) {
 
 // TODO: Test this impl
 function getBlacklist(cb) {
-  https.get(url, onRequest);
+  request(url, function(error, response, body) {
+    processResponse(error, response, body);
+  });
 
-  function onRequest(res) {
-    if (res.statusCode !== 200) {
+  function processResponse(error, response, body) {
+    if (error || (response && response.statusCode !== 200)) {
       // TODO: Test different status codes
-      return cb(new Error('Request failed. Status Code: ' + res.statusCode));
+      return cb(new Error(response
+        ? 'Request failed. Status Code: ' + response.statusCode
+        : error));
     }
 
-    res.setEncoding('utf8');
-
-    collect(res, onCollect);
-  }
-
-  function onCollect(err, result) {
-    if (err) {
-      return cb(err);
-    }
-
-    parse(result, onParse);
+    parse(body, onParse);
   }
 
   function onParse(err, blacklist) {

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "ansi-colors": "^1.0.1",
     "archy": "^1.0.0",
     "array-sort": "^1.0.0",
-    "concat-stream": "^1.6.0",
     "color-support": "^1.1.3",
+    "concat-stream": "^1.6.0",
     "copy-props": "^2.0.1",
     "fancy-log": "^1.3.2",
     "gulplog": "^1.0.0",
@@ -46,6 +46,7 @@
     "mute-stdout": "^1.0.0",
     "pretty-hrtime": "^1.0.0",
     "replace-homedir": "^1.0.0",
+    "request": "^2.88.0",
     "semver-greatest-satisfied-range": "^1.1.0",
     "v8flags": "^3.0.1",
     "yargs": "^7.1.0"


### PR DESCRIPTION
I would like to use "gulp --verify" behind a proxy server. The current implementation does not seem to be able to support a proxy configuration.

Solution: Replace "https" by "request" in get-blacklist.js to allow for proxy configuration.