### PR TITLE
format-error.js: Prefer `e.error.message` if available

### DIFF
--- a/lib/versioned/^3.7.0/format-error.js
+++ b/lib/versioned/^3.7.0/format-error.js
@@ -17,7 +17,7 @@ function formatError(e) {
   }
 
   // Unknown (string, number, etc.)
-  return new Error(String(e.err)).stack;
+  return new Error(String(e.err.message || e.err)).stack;
 }
 
 module.exports = formatError;

--- a/lib/versioned/^4.0.0/format-error.js
+++ b/lib/versioned/^4.0.0/format-error.js
@@ -17,7 +17,7 @@ function formatError(e) {
   }
 
   // Unknown (string, number, etc.)
-  return new Error(String(e.error)).stack;
+  return new Error(String(e.error.message || e.error)).stack;
 }
 
 module.exports = formatError;


### PR DESCRIPTION
Previously when using `e.error` and it was an object, we got just an "[object Object]" message in the resulting Error object (and error message in terminal). With this patch instead when there is a `message` property inside `e.error`, use that to get a better error report, and falling back to old behaviour in other cases.