### PR TITLE
Show error info for --require param problem

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,10 @@ cli.on('require', function(name) {
 
 cli.on('requireFail', function(name, error) {
   var message = name + (error ? ' [' + error + ']' : '');
-  log.warn(ansi.yellow('Failed to load external module'), ansi.magenta(message));
+  log.warn(
+    ansi.yellow('Failed to load external module'),
+    ansi.magenta(message)
+  );
 });
 
 cli.on('respawn', function(flags, child) {

--- a/index.js
+++ b/index.js
@@ -69,11 +69,13 @@ cli.on('require', function(name) {
 });
 
 cli.on('requireFail', function(name, error) {
-  var message = name + (error ? ' [' + error + ']' : '');
   log.warn(
     ansi.yellow('Failed to load external module'),
-    ansi.magenta(message)
+    ansi.magenta(name)
   );
+  if (error) {
+    log.warn(ansi.yellow(error.toString()));
+  }
 });
 
 cli.on('respawn', function(flags, child) {

--- a/index.js
+++ b/index.js
@@ -68,8 +68,9 @@ cli.on('require', function(name) {
   log.info('Requiring external module', ansi.magenta(name));
 });
 
-cli.on('requireFail', function(name) {
-  log.warn(ansi.yellow('Failed to load external module'), ansi.magenta(name));
+cli.on('requireFail', function(name, error) {
+  var message = name + (error ? ' [' + error + ']' : '');
+  log.warn(ansi.yellow('Failed to load external module'), ansi.magenta(message));
 });
 
 cli.on('respawn', function(flags, child) {

--- a/test/exports-as-tasks.js
+++ b/test/exports-as-tasks.js
@@ -25,7 +25,7 @@ describe('exports as tasks', function() {
       var filepath = path.join(expectedDir, 'tasks-as-exports.txt');
       var expected = fs.readFileSync(filepath, 'utf-8');
       // Remove babel/register lines
-      stdout = eraseTime(skipLines(stdout, 3));
+      stdout = eraseTime(skipLines(stdout, 4));
       expect(stdout).toEqual(expected);
       done(err);
     }

--- a/test/fixtures/test-error-module.js
+++ b/test/fixtures/test-error-module.js
@@ -1,0 +1,2 @@
+throw new Error('from error module');
+console.log('inside error module');

--- a/test/flags-require.js
+++ b/test/flags-require.js
@@ -90,4 +90,42 @@ describe('flag: --require', function() {
     }
   });
 
+  it('warns if module throw some error', function(done) {
+    runner({ verbose: false })
+      .gulp('--require ../test-error-module.js', '--cwd ./test/fixtures/gulpfiles')
+      .run(cb);
+
+    function cb(err, stdout, stderr) {
+      stdout = eraseLapse(eraseTime(stdout));
+      expect(err).toEqual(null);
+      expect(stderr).toEqual('');
+      expect(stdout).toMatch('Failed to load external module ../test-error-module.js [Error: from error module]');
+      expect(stdout).toNotMatch('inside error module');
+
+      var chgWorkdirLog = headLines(stdout, 2);
+      var workdir = 'test/fixtures/gulpfiles'.replace(/\//g, path.sep);
+      expect(chgWorkdirLog).toMatch('Working directory changed to ');
+      expect(chgWorkdirLog).toMatch(workdir);
+
+      stdout = eraseLapse(eraseTime(skipLines(stdout, 3)));
+      expect(stdout).toEqual(
+        'Starting \'default\'...\n' +
+         'Starting \'test1\'...\n' +
+          'Starting \'noop\'...\n' +
+          'Finished \'noop\' after ?\n' +
+         'Finished \'test1\' after ?\n' +
+         'Starting \'test3\'...\n' +
+          'Starting \'described\'...\n' +
+          'Finished \'described\' after ?\n' +
+         'Finished \'test3\' after ?\n' +
+         'Starting \'noop\'...\n' +
+         'Finished \'noop\' after ?\n' +
+        'Finished \'default\' after ?\n' +
+        ''
+      );
+
+      done(err);
+    }
+  });
+
 });

--- a/test/flags-require.js
+++ b/test/flags-require.js
@@ -60,16 +60,16 @@ describe('flag: --require', function() {
       expect(stderr).toEqual('');
       stdout = eraseLapse(eraseTime(stdout));
       expect(stdout).toMatch('Failed to load external module ./null-module.js');
+      expect(stdout).toMatch('Error: Cannot find module \'./null-module.js\'');
       expect(stdout).toNotMatch('inside test module');
-      expect(stdout).toNotMatch(
-        'Requiring external module ../test-module.js');
+      expect(stdout).toNotMatch('Requiring external module ../test-module.js');
 
-      var chgWorkdirLog = headLines(stdout, 2);
+      var chgWorkdirLog = headLines(stdout, 3);
       var workdir = 'test/fixtures/gulpfiles'.replace(/\//g, path.sep);
       expect(chgWorkdirLog).toMatch('Working directory changed to ');
       expect(chgWorkdirLog).toMatch(workdir);
 
-      stdout = eraseLapse(eraseTime(skipLines(stdout, 3)));
+      stdout = eraseLapse(eraseTime(skipLines(stdout, 4)));
       expect(stdout).toEqual(
         'Starting \'default\'...\n' +
          'Starting \'test1\'...\n' +
@@ -99,15 +99,16 @@ describe('flag: --require', function() {
       stdout = eraseLapse(eraseTime(stdout));
       expect(err).toEqual(null);
       expect(stderr).toEqual('');
-      expect(stdout).toMatch('Failed to load external module ../test-error-module.js [Error: from error module]');
+      expect(stdout).toMatch('Failed to load external module ../test-error-module.js');
+      expect(stdout).toMatch('Error: from error module');
       expect(stdout).toNotMatch('inside error module');
 
-      var chgWorkdirLog = headLines(stdout, 2);
+      var chgWorkdirLog = headLines(stdout, 3);
       var workdir = 'test/fixtures/gulpfiles'.replace(/\//g, path.sep);
       expect(chgWorkdirLog).toMatch('Working directory changed to ');
       expect(chgWorkdirLog).toMatch(workdir);
 
-      stdout = eraseLapse(eraseTime(skipLines(stdout, 3)));
+      stdout = eraseLapse(eraseTime(skipLines(stdout, 4)));
       expect(stdout).toEqual(
         'Starting \'default\'...\n' +
          'Starting \'test1\'...\n' +


### PR DESCRIPTION
I spent some time to figure out why: `gulp --require @babel/register ...` not works. Was missing `@babel/core` :]