### PR TITLE
Support `flags.nodeFlags` config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Supported configurations properties:
 | flags.silent       | Silence logging by default |
 | flags.series       | Run tasks given on the CLI in series (the default is parallel) |
 | flags.require      | An array of modules to require before running the gulpfile. Any relative paths will be resolved against the `--cwd` directory (if you don't want that behavior, use absolute paths) |
+| flags.nodeFlags    | An array of flags used to forcibly respawn the process upon startup. For example, if you always want your gulpfiles to run in node's harmony mode, you can set `--harmony` here |
 
 ## Flags
 

--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ function run() {
     // Set up event listeners for logging again after configuring.
     toConsole(log, opts);
 
-    cli.execute(env, handleArguments);
+    cli.execute(env, env.nodeFlags, handleArguments);
   });
 }
 

--- a/lib/shared/config/env-flags.js
+++ b/lib/shared/config/env-flags.js
@@ -7,6 +7,7 @@ var toFrom = {
   configPath: 'flags.gulpfile',
   configBase: 'flags.gulpfile',
   require: 'flags.require',
+  nodeFlags: 'flags.nodeFlags',
 };
 
 function mergeConfigToEnvFlags(env, config, cliOpts) {
@@ -31,6 +32,10 @@ function mergeConfigToEnvFlags(env, config, cliOpts) {
 
     if (envInfo.keyChain === 'require') {
       return [].concat(envInfo.value, configInfo.value);
+    }
+
+    if (envInfo.keyChain === 'nodeFlags') {
+      return [].concat(configInfo.value || []);
     }
 
     return configInfo.value;

--- a/test/config-flags-node-flags.js
+++ b/test/config-flags-node-flags.js
@@ -1,0 +1,70 @@
+'use strict';
+
+var expect = require('expect');
+var path = require('path');
+
+var fixturesDir = path.join(__dirname, 'fixtures/config');
+
+var runner = require('gulp-test-tools').gulpRunner().basedir(fixturesDir);
+var headLines = require('gulp-test-tools').headLines;
+var eraseTime = require('gulp-test-tools').eraseTime;
+
+describe('config: nodeFlags', function() {
+
+  it('Should respawn by a node flag: --lazy', function(done) {
+    runner
+      .chdir('flags/nodeFlags/string')
+      .gulp()
+      .run(cb);
+
+    function cb(err, stdout, stderr) {
+      expect(err).toEqual(null);
+      expect(stderr).toEqual('');
+
+      var line = eraseTime(headLines(stdout, 1));
+      expect(line).toEqual('Node flags detected: --lazy');
+
+      line = eraseTime(headLines(stdout, 2, 1));
+      expect(line).toMatch('Respawned to PID: ');
+      done(err);
+    }
+  });
+
+  it('Should respawn by a node flag: --lazy --trace-deprecation', function(done) {
+    runner
+      .chdir('flags/nodeFlags/array')
+      .gulp()
+      .run(cb);
+
+    function cb(err, stdout, stderr) {
+      expect(err).toEqual(null);
+      expect(stderr).toEqual('');
+
+      var line = eraseTime(headLines(stdout, 1));
+      expect(line).toEqual('Node flags detected: --lazy, --trace-deprecation');
+
+      line = eraseTime(headLines(stdout, 2, 1));
+      expect(line).toMatch('Respawned to PID: ');
+      done(err);
+    }
+  });
+
+  it('Should respawn with flags in config file and command line', function(done) {
+    runner
+      .chdir('flags/nodeFlags/string')
+      .gulp('--harmony')
+      .run(cb);
+
+    function cb(err, stdout, stderr) {
+      expect(err).toEqual(null);
+      expect(stderr).toEqual('');
+
+      var line = eraseTime(headLines(stdout, 1));
+      expect(line).toEqual('Node flags detected: --lazy, --harmony');
+
+      line = eraseTime(headLines(stdout, 2, 1));
+      expect(line).toMatch('Respawned to PID: ');
+      done(err);
+    }
+  });
+});

--- a/test/fixtures/config/flags/nodeFlags/array/.gulp.json
+++ b/test/fixtures/config/flags/nodeFlags/array/.gulp.json
@@ -1,0 +1,5 @@
+{
+  "flags": {
+    "nodeFlags": ["--lazy", "--trace-deprecation"]
+  }
+}

--- a/test/fixtures/config/flags/nodeFlags/array/gulpfile.js
+++ b/test/fixtures/config/flags/nodeFlags/array/gulpfile.js
@@ -1,0 +1,6 @@
+'use strict';
+
+exports.default = function(done) {
+  console.log('Default');
+  done();
+};

--- a/test/fixtures/config/flags/nodeFlags/string/.gulp.js
+++ b/test/fixtures/config/flags/nodeFlags/string/.gulp.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+  flags: {
+    nodeFlags: '--lazy',
+  },
+};

--- a/test/fixtures/config/flags/nodeFlags/string/gulpfile.js
+++ b/test/fixtures/config/flags/nodeFlags/string/gulpfile.js
@@ -1,0 +1,6 @@
+'use strict';
+
+exports.default = function(done) {
+  console.log('Default');
+  done();
+};

--- a/test/flags-v8flags.js
+++ b/test/flags-v8flags.js
@@ -1,0 +1,49 @@
+'use strict';
+
+var expect = require('expect');
+var path = require('path');
+
+var runner = require('gulp-test-tools').gulpRunner;
+var headLines = require('gulp-test-tools').headLines;
+var eraseTime = require('gulp-test-tools').eraseTime;
+
+describe('flags: v8flags', function() {
+
+  it('Should respawn by a v8flag: --lazy', function(done) {
+    runner({ verbose: false })
+      .chdir(path.join(__dirname, 'fixtures/gulpfiles'))
+      .gulp('--lazy')
+      .run(cb);
+
+    function cb(err, stdout, stderr) {
+      expect(err).toEqual(null);
+      expect(stderr).toEqual('');
+
+      var line = eraseTime(headLines(stdout, 1));
+      expect(line).toEqual('Node flags detected: --lazy');
+
+      line = eraseTime(headLines(stdout, 2, 1));
+      expect(line).toMatch('Respawned to PID: ');
+      done(err);
+    }
+  });
+
+  it('Should respawn by v8flags: --lazy --harmony', function(done) {
+    runner({ verbose: false })
+      .chdir(path.join(__dirname, 'fixtures/gulpfiles'))
+      .gulp('--lazy --harmony')
+      .run(cb);
+
+    function cb(err, stdout, stderr) {
+      expect(err).toEqual(null);
+      expect(stderr).toEqual('');
+
+      var line = eraseTime(headLines(stdout, 1));
+      expect(line).toEqual('Node flags detected: --harmony, --lazy');
+
+      line = eraseTime(headLines(stdout, 2, 1));
+      expect(line).toMatch('Respawned to PID: ');
+      done(err);
+    }
+  });
+});


### PR DESCRIPTION
This pr adds support of `flags.nodeFlags` in config files and test cases for `v8flags` of CLI option.