### PR TITLE
Fix: Honor displayName in ESM exports.

### DIFF
--- a/lib/shared/register-exports.js
+++ b/lib/shared/register-exports.js
@@ -14,7 +14,7 @@ function registerExports(gulpInst, tasks) {
       return;
     }
 
-    gulpInst.task(taskName, task);
+    gulpInst.task(task.displayName || taskName, task);
   }
 }
 

--- a/test/expected/tasks-as-exports.txt
+++ b/test/expected/tasks-as-exports.txt
@@ -1,7 +1,20 @@
 gulp-cli/test/fixtures/gulpfiles
 ├── build
 ├── clean
-└─┬ dist
+├─┬ dist
+│ └─┬ <series>
+│   ├── clean
+│   └── build
+├── f-test
+├─┬ p
+│ └─┬ <parallel>
+│   ├── p1
+│   └── p2
+├─┬ p-test
+│ └─┬ <parallel>
+│   ├── p1
+│   └── p2
+└─┬ s-test
   └─┬ <series>
     ├── clean
     └── build

--- a/test/fixtures/gulpfiles/gulpfile-exports.babel.js
+++ b/test/fixtures/gulpfiles/gulpfile-exports.babel.js
@@ -8,3 +8,15 @@ export function clean(){};
 export function build(){};
 export const string = 'no function';
 export const dist = gulp.series(clean, build);
+function p1(){}
+function p2(){}
+export const p = gulp.parallel(p1, p2);
+
+export const sTest = gulp.series(clean, build);
+sTest.displayName = 's-test';
+
+export const pTest = gulp.parallel(p1, p2);
+pTest.displayName = 'p-test';
+
+export function fTest(){};
+fTest.displayName = 'f-test';


### PR DESCRIPTION
This reimplements #53 and expands the regression test to include
parallel tasks.

Fixes gulpjs/gulp#2270