### PR TITLE
bump dependencies, remove unmaintained node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 sudo: false
 language: node_js
 node_js:
+  - "12"
   - "10"
   - "8"
   - "6"
-  - "4"
-  - "0.12"
-  - "0.10"
 after_script:
   - if [ $(echo "${TRAVIS_NODE_VERSION}" | cut -d'.' -f1) -ge 6 ]; then
       npm run coveralls;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,15 +4,13 @@
 environment:
   matrix:
     # node.js
-    - nodejs_version: "0.10"
-    - nodejs_version: "0.12"
-    - nodejs_version: "4"
     - nodejs_version: "6"
     - nodejs_version: "8"
     - nodejs_version: "10"
+    - nodejs_version: "12"
 
 install:
-  - npm install -g npm@^3
+  - npm install -g npm@^6
   - ps: Install-Product node $env:nodejs_version
   - npm install
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "man": "gulp.1",
   "engines": {
-    "node": ">= 0.10"
+    "node": ">= 6"
   },
   "main": "index.js",
   "bin": {
@@ -31,16 +31,16 @@
     "coveralls": "nyc --reporter=text-lcov npm test | coveralls"
   },
   "dependencies": {
-    "ansi-colors": "^1.0.1",
+    "ansi-colors": "^4.1.1",
     "archy": "^1.0.0",
     "array-sort": "^1.0.0",
-    "concat-stream": "^1.6.0",
     "color-support": "^1.1.3",
+    "concat-stream": "^1.6.0",
     "copy-props": "^2.0.1",
     "fancy-log": "^1.3.2",
     "gulplog": "^1.0.0",
     "interpret": "^1.1.0",
-    "isobject": "^3.0.1",
+    "isobject": "^4.0.0",
     "liftoff": "^3.1.0",
     "matchdep": "^2.0.0",
     "mute-stdout": "^1.0.0",
@@ -59,10 +59,11 @@
     "expect": "^1.20.2",
     "gulp": "^4.0.0",
     "gulp-test-tools": "^0.6.1",
-    "marked-man": "^0.2.1",
-    "mocha": "^3.2.0",
-    "nyc": "^13.3.0",
-    "rimraf": "^2.6.1"
+    "marked": "^0.7.0",
+    "marked-man": "^0.7.0",
+    "mocha": "^6.2.0",
+    "nyc": "^14.1.1",
+    "rimraf": "^3.0.0"
   },
   "keywords": [
     "build",


### PR DESCRIPTION
 The main goal of this PR is to get rid of scary-looking warnings from npm audit and do a little house-cleaning on the deps. There's still a few more in `gulp-test-tools`, but I sent a PR over there as well and if that works out, we can bump the package.json over here to reflect that and clear up all those warnings.

Some of the newer versions of dependencies (mocha, for example) dropped support for older unmaintained node versions (<6), so that's been pulled from the CI builds and indicated in the package.json as well.