### PR TITLE
Use path.join to concatenate paths to support Windows extended-length paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ var logVerify = require('./lib/shared/log/verify');
 var logBlacklistError = require('./lib/shared/log/blacklist-error');
 
 // Get supported ranges
-var ranges = fs.readdirSync(__dirname + '/lib/versioned/');
+var ranges = fs.readdirSync(path.join(__dirname, '/lib/versioned/'));
 
 // Set env var for ORIGINAL cwd
 // before anything touches it


### PR DESCRIPTION
Closes #200 

Info
-----
Windows extended-length paths don't support `/` as a path separator, so building a path using string concatenation will fail if the path is extended-length. This causes gulp to fail if it is invoked with an extended-length path, since that causes `__dirname` to be extended-length.

Changes
-----
Updated the path building in `index.js` to use `path.join()`

Tested
-----
Invoked `gulp -v` using an extended-length path and verified that it runs correctly and doesn't throw an error.