### PR TITLE
Fix false positive reporting of sync tasks on errors

### DIFF
--- a/lib/versioned/^4.0.0/log/sync-task.js
+++ b/lib/versioned/^4.0.0/log/sync-task.js
@@ -35,12 +35,18 @@ function clear(e) {
   delete tasks[e.uid];
 }
 
+function clearAll() {
+  tasks = {};
+}
+
 function logSyncTask(gulpInst) {
 
   process.once('exit', warn);
   gulpInst.on('start', start);
   gulpInst.on('stop', clear);
-  gulpInst.on('error', clear);
+  // When not running in --continue mode, we need to clear everything on error to avoid
+  // false positives.
+  gulpInst.on('error', process.env.UNDERTAKER_SETTLE === 'true' ? clear : clearAll);
 }
 
 module.exports = logSyncTask;

--- a/test/fixtures/gulpfiles/gulpfile-parallel-failure.js
+++ b/test/fixtures/gulpfiles/gulpfile-parallel-failure.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var gulp = require('gulp');
+
+function noop(cb) {
+  cb();
+}
+
+function errorFunction(cb) {
+  cb(new Error('Error!'));
+}
+
+function notCompleting1() {
+  // Callback is not called
+}
+
+gulp.task('default', gulp.parallel(errorFunction, noop));
+gulp.task('broken', gulp.parallel(errorFunction, noop, notCompleting1));

--- a/test/non-completing-tasks.js
+++ b/test/non-completing-tasks.js
@@ -33,4 +33,31 @@ describe('sync-task', function() {
         done();
       });
   });
+
+  it('should not log false positive in case of parallel failure', function(done) {
+    runner({ verbose: false })
+      .gulp('--gulpfile ./test/fixtures/gulpfiles/gulpfile-parallel-failure.js')
+      .run(function(err, stdout) {
+        expect(stdout).toExclude('The following tasks did not complete:');
+        done();
+      });
+  });
+
+  it('should not log false positive in case of parallel failure in continue mode', function(done) {
+    runner({ verbose: false })
+      .gulp('--continue --gulpfile ./test/fixtures/gulpfiles/gulpfile-parallel-failure.js')
+      .run(function(err, stdout) {
+        expect(stdout).toExclude('The following tasks did not complete:');
+        done();
+      });
+  });
+
+  it('should log non-completing task alongside a failure in continue mode', function(done) {
+    runner({ verbose: false })
+      .gulp('--continue --gulpfile ./test/fixtures/gulpfiles/gulpfile-parallel-failure.js broken')
+      .run(function(err, stdout) {
+        expect(stdout).toInclude('The following tasks did not complete: broken, notCompleting1\n');
+        done();
+      });
+  });
 });


### PR DESCRIPTION
When a failure happens in a parallel task, it is totally normal that other tasks have not reported completion, as gulp.parallel will report the error without waiting for other tasks.

Closes #203 
Closes #162