### PR TITLE
Fix ERR_UNSUPPORTED_DIR_IMPORT for gulpfile.mjs

### DIFF
--- a/lib/shared/require-or-import.js
+++ b/lib/shared/require-or-import.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var pathToFileURL = require('url').pathToFileURL;
+var pathStatsSync = require('fs').lstatSync;
+var join = require('path').join;
 
 var importESM;
 try {
@@ -12,6 +14,28 @@ try {
   importESM = null;
 }
 
+function securePath(path) {
+  var pathStatsSync = require('fs').lstatSync;
+  var join = require('path').join;
+
+  // Avoid ERR_UNSUPPORTED_DIR_IMPORT (>=NodeJs 12)
+  var validPath = pathStatsSync(path).isDirectory() ?
+    join(path, 'index.mjs') :
+    path;
+
+  // This is needed on Windows, because import() fails if providing a Windows file path.
+  return pathToFileURL(validPath);
+}
+
+function onImportESM(path, callback) {
+  var safePath = securePath(path);
+  importESM(safePath)
+    .then(function(modules) {
+      callback(null, modules);
+    })
+    .catch(callback);
+}
+
 function requireOrImport(path, callback) {
   var err = null;
   var cjs;
@@ -19,14 +43,11 @@ function requireOrImport(path, callback) {
     cjs = require(path);
   } catch (e) {
     if (pathToFileURL && importESM && e.code === 'ERR_REQUIRE_ESM') {
-      // This is needed on Windows, because import() fails if providing a Windows file path.
-      var url = pathToFileURL(path);
-      importESM(url).then(function(esm) { callback(null, esm); }, callback);
-      return;
+      return onImportESM(path, callback);
     }
     err = e;
   }
-  process.nextTick(function() { callback(err, cjs); });
+  process.nextTick(function () { callback(err, cjs); });
 }
 
 module.exports = requireOrImport;

--- a/lib/shared/require-or-import.js
+++ b/lib/shared/require-or-import.js
@@ -1,8 +1,6 @@
 'use strict';
 
 var pathToFileURL = require('url').pathToFileURL;
-var pathStatsSync = require('fs').lstatSync;
-var join = require('path').join;
 
 var importESM;
 try {

--- a/lib/shared/require-or-import.js
+++ b/lib/shared/require-or-import.js
@@ -12,13 +12,20 @@ try {
   importESM = null;
 }
 
+function getExt(path) {
+  // Remove trailling slash `/`
+  // and get gulpfile extension
+  var regex = /.([\w\d]+)\/*$/i;
+  return path.match(regex)[1];
+}
+
 function securePath(path) {
   var pathStatsSync = require('fs').lstatSync;
   var join = require('path').join;
 
-  // Avoid ERR_UNSUPPORTED_DIR_IMPORT (>=NodeJs 12)
+  // Avoid ERR_UNSUPPORTED_DIR_IMPORT (NodeJs >= 12)
   var validPath = pathStatsSync(path).isDirectory() ?
-    join(path, 'index.mjs') :
+    join(path, 'index.' + getExt(path)) :
     path;
 
   // This is needed on Windows, because import() fails if providing a Windows file path.
@@ -45,7 +52,7 @@ function requireOrImport(path, callback) {
     }
     err = e;
   }
-  process.nextTick(function () { callback(err, cjs); });
+  process.nextTick(function() { callback(err, cjs); });
 }
 
 module.exports = requireOrImport;


### PR DESCRIPTION
### What is this PR for?
This is a ERR_UNSUPPORTED_DIR_IMPORT fixed patch. (And did a bit code refactor in `require-or-import.js` file)

Before this patch, gulp-cli won't be able to read directory URL for ESM mode. For example:
```TXT
/gulpfile.js		# work
/gulpfile.js/index.js	# work
/gulpfile.mjs		# work
/gulpfile.mjs/index.mjs	# fail
```
The only solution is append `index.mjs` to the directory. And I fixed it.

### Was it tested yet?
Almost everything.

- [x] It should not break anything -> Tested with mocha testcases (available in this repo)
- [x] It should be able to read `gulpfile.mjs` directory -> Tested directly in my own repo (a)
- [ ] A mocha testcase for reading `gulpfile.mjs` directory -> I have no idea how to do it, so this task is under researching

#### If it possible, I would like to merge this patch to gulp-cli.

