### PR TITLE
upgrade yargs

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,9 +58,10 @@ var usage =
   '\n' + ansi.bold('Usage:') +
   ' gulp ' + ansi.blue('[options]') + ' tasks';
 
+yargs.version(false);
 var parser = yargs.usage(usage);
 Object.keys(cliOptions).forEach(function(k) {
-  parser.option(k, cliOptions[k]);
+  parser = parser.option(k, cliOptions[k]);
 });
 
 var opts = parser.argv;

--- a/index.js
+++ b/index.js
@@ -58,7 +58,11 @@ var usage =
   '\n' + ansi.bold('Usage:') +
   ' gulp ' + ansi.blue('[options]') + ' tasks';
 
-var parser = yargs.usage(usage, cliOptions);
+var parser = yargs.usage(usage);
+Object.keys(cliOptions).forEach(function(k) {
+  parser.option(k, cliOptions[k]);
+});
+
 var opts = parser.argv;
 
 cli.on('require', function(name) {

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "ansi-colors": "^1.0.1",
     "archy": "^1.0.0",
     "array-sort": "^1.0.0",
-    "concat-stream": "^1.6.0",
     "color-support": "^1.1.3",
+    "concat-stream": "^1.6.0",
     "copy-props": "^2.0.1",
     "fancy-log": "^1.3.2",
     "gulplog": "^1.0.0",
@@ -48,7 +48,7 @@
     "replace-homedir": "^1.0.0",
     "semver-greatest-satisfied-range": "^1.1.0",
     "v8flags": "^3.2.0",
-    "yargs": "^7.1.0"
+    "yargs": "^16.0.3"
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.5.0",

--- a/test/expected/flags-help.txt
+++ b/test/expected/flags-help.txt
@@ -1,38 +1,41 @@
-
 Usage: gulp [options] tasks
 
 Options:
-  --help, -h              Show this help.                              [boolean]
-  --version, -v           Print the global and local gulp versions.    [boolean]
-  --require               Will require a module before running the gulpfile.
-                          This is useful for transpilers but also has other
-                          applications.                                 [string]
-  --gulpfile, -f          Manually set path of gulpfile. Useful if you have
-                          multiple gulpfiles. This will set the CWD to the
-                          gulpfile directory as well.                   [string]
-  --cwd                   Manually set the CWD. The search for the gulpfile, as
-                          well as the relativity of all requires will be from
-                          here.                                         [string]
-  --verify                Will verify plugins referenced in project's
-                          package.json against the plugins blacklist.
-  --tasks, -T             Print the task dependency tree for the loaded
-                          gulpfile.                                    [boolean]
-  --tasks-simple          Print a plaintext list of tasks for the loaded
-                          gulpfile.                                    [boolean]
-  --tasks-json            Print the task dependency tree, in JSON format, for
-                          the loaded gulpfile.
-  --tasks-depth, --depth  Specify the depth of the task dependency tree.[number]
-  --compact-tasks         Reduce the output of task dependency tree by printing
-                          only top tasks and their child tasks.        [boolean]
-  --sort-tasks            Will sort top tasks of task dependency tree. [boolean]
-  --color                 Will force gulp and gulp plugins to display colors,
-                          even when no color support is detected.      [boolean]
-  --no-color              Will force gulp and gulp plugins to not display
-                          colors, even when color support is detected. [boolean]
-  --silent, -S            Suppress all gulp logging.                   [boolean]
-  --continue              Continue execution of tasks upon failure.    [boolean]
-  --series                Run tasks given on the CLI in series (the default is
-                          parallel).                                   [boolean]
-  --log-level, -L         Set the loglevel. -L for least verbose and -LLLL for
-                          most verbose. -LLL is default.                 [count]
-
+  -h, --help                  Show this help.                          [boolean]
+  -v, --version               Print the global and local gulp versions.[boolean]
+      --require               Will require a module before running the gulpfile.
+                              This is useful for transpilers but also has other
+                              applications.                             [string]
+  -f, --gulpfile              Manually set path of gulpfile. Useful if you have
+                              multiple gulpfiles. This will set the CWD to the
+                              gulpfile directory as well.               [string]
+      --cwd                   Manually set the CWD. The search for the gulpfile,
+                              as well as the relativity of all requires will be
+                              from here.                                [string]
+      --verify                Will verify plugins referenced in project's
+                              package.json against the plugins blacklist.
+  -T, --tasks                 Print the task dependency tree for the loaded
+                              gulpfile.                                [boolean]
+      --tasks-simple          Print a plaintext list of tasks for the loaded
+                              gulpfile.                                [boolean]
+      --tasks-json            Print the task dependency tree, in JSON format,
+                              for the loaded gulpfile.
+      --tasks-depth, --depth  Specify the depth of the task dependency tree.
+                                                                        [number]
+      --compact-tasks         Reduce the output of task dependency tree by
+                              printing only top tasks and their child tasks.
+                                                                       [boolean]
+      --sort-tasks            Will sort top tasks of task dependency tree.
+                                                                       [boolean]
+      --color                 Will force gulp and gulp plugins to display
+                              colors, even when no color support is detected.
+                                                                       [boolean]
+      --no-color              Will force gulp and gulp plugins to not display
+                              colors, even when color support is detected.
+                                                                       [boolean]
+  -S, --silent                Suppress all gulp logging.               [boolean]
+      --continue              Continue execution of tasks upon failure.[boolean]
+      --series                Run tasks given on the CLI in series (the default
+                              is parallel).                            [boolean]
+  -L, --log-level             Set the loglevel. -L for least verbose and -LLLL
+                              for most verbose. -LLL is default.         [count]

--- a/test/fixtures/logging.js
+++ b/test/fixtures/logging.js
@@ -3,7 +3,10 @@ var yargs = require('yargs');
 var toConsole = require('../../lib/shared/log/to-console');
 var cliOptions = require('../../lib/shared/cli-options');
 
-var parser = yargs.usage('', cliOptions);
+var parser = yargs.usage('');
+Object.keys(cliOptions).forEach(function(k) {
+  parser.option(k, cliOptions[k]);
+});
 var opts = parser.argv;
 
 toConsole(log, opts);

--- a/test/fixtures/logging.js
+++ b/test/fixtures/logging.js
@@ -3,10 +3,12 @@ var yargs = require('yargs');
 var toConsole = require('../../lib/shared/log/to-console');
 var cliOptions = require('../../lib/shared/cli-options');
 
+yargs.version(false);
 var parser = yargs.usage('');
 Object.keys(cliOptions).forEach(function(k) {
-  parser.option(k, cliOptions[k]);
+  parser = parser.option(k, cliOptions[k]);
 });
+
 var opts = parser.argv;
 
 toConsole(log, opts);

--- a/test/flags-help.js
+++ b/test/flags-help.js
@@ -25,7 +25,7 @@ describe('flag: --help', function() {
       expect(err).toEqual(null);
       expect(stderr).toEqual('');
       stdout = eraseFirstSpace(stdout);
-      expect(stdout).toEqual(outputText);
+      expect(stdout.trim()).toEqual(outputText.trim());
       done(err);
     }
   });
@@ -39,7 +39,7 @@ describe('flag: --help', function() {
       expect(err).toEqual(null);
       expect(stderr).toEqual('');
       stdout = eraseFirstSpace(stdout);
-      expect(stdout).toEqual(outputText);
+      expect(stdout.trim()).toEqual(outputText.trim());
       done(err);
     }
   });
@@ -53,7 +53,7 @@ describe('flag: --help', function() {
       expect(err).toEqual(null);
       expect(stderr).toEqual('');
       stdout = eraseFirstSpace(stdout);
-      expect(stdout).toEqual(outputText);
+      expect(stdout.trim()).toEqual(outputText.trim());
       done(err);
     }
   });


### PR DESCRIPTION
I (and probably others) are getting security alerts due to an old version of `yargs-parser` brought in by an old version of `yargs`, brought in by `gulp-cli`, ultimately brought in by `gulp`. This is the first step in fixing that chain: updating gulp-cli to use the current version of `yargs`.