### PR TITLE
Bump yargs from 7.1.0 to 16.2.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ var usage =
   '\n' + ansi.bold('Usage:') +
   ' gulp ' + ansi.blue('[options]') + ' tasks';
 
-var parser = yargs.usage(usage, cliOptions);
+var parser = yargs.usage(usage).options(cliOptions);
 var opts = parser.argv;
 
 cli.on('require', function(name) {

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "ansi-colors": "^1.0.1",
     "archy": "^1.0.0",
     "array-sort": "^1.0.0",
-    "concat-stream": "^1.6.0",
     "color-support": "^1.1.3",
+    "concat-stream": "^1.6.0",
     "copy-props": "^2.0.1",
     "fancy-log": "^1.3.2",
     "gulplog": "^1.0.0",
@@ -48,7 +48,7 @@
     "replace-homedir": "^1.0.0",
     "semver-greatest-satisfied-range": "^1.1.0",
     "v8flags": "^3.2.0",
-    "yargs": "^7.1.0"
+    "yargs": "^16.2.0"
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.5.0",

--- a/test/fixtures/logging.js
+++ b/test/fixtures/logging.js
@@ -3,7 +3,7 @@ var yargs = require('yargs');
 var toConsole = require('../../lib/shared/log/to-console');
 var cliOptions = require('../../lib/shared/cli-options');
 
-var parser = yargs.usage('', cliOptions);
+var parser = yargs.usage('').options(cliOptions);
 var opts = parser.argv;
 
 toConsole(log, opts);


### PR DESCRIPTION
8This PR updates yargs to the latest version. This closes a few security audit advisories.

There was one small breaking change in the signature of `.usage()`. The tests pass on Node 10 and 14.