### PR TITLE
Update yargs version to 15.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "ansi-colors": "^1.0.1",
     "archy": "^1.0.0",
     "array-sort": "^1.0.0",
-    "concat-stream": "^1.6.0",
     "color-support": "^1.1.3",
+    "concat-stream": "^1.6.0",
     "copy-props": "^2.0.1",
     "fancy-log": "^1.3.2",
     "gulplog": "^1.0.0",
@@ -48,7 +48,7 @@
     "replace-homedir": "^1.0.0",
     "semver-greatest-satisfied-range": "^1.1.0",
     "v8flags": "^3.2.0",
-    "yargs": "^7.1.0"
+    "yargs": "^15.4.0"
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.5.0",


### PR DESCRIPTION
This PR goal to fix vulnerabity security.

yargs-parser is a dependency of yargs which have a "Prototype Pollution" fixed on >=18.1.2 versions. yargs call this new version since its 15.4.0 release.