### PR TITLE
chore!: Fix dependency vulnerabilities discovered by Snyk

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,17 @@
     "rimraf": "^2.6.1",
     "semver": "^5.7.1"
   },
+  "overrides": {
+    "cache-base": {
+      "unset-value": "2.0.1"
+    },
+    "os-locale": {
+      "mem": "4.0.0"
+    },
+    "strip-ansi": {
+      "ansi-regex": "3.0.1"
+    }
+  },
   "keywords": [
     "build",
     "stream",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "scripts": {
     "lint": "eslint .",
     "prepublish": "marked-man --name gulp docs/CLI.md > gulp.1",
-    "pretest": "npm run lint",
     "test": "mocha --async-only --timeout 5000 test/lib test",
     "cover": "nyc --reporter=lcov --reporter=text-summary npm test",
     "coveralls": "nyc --reporter=text-lcov npm test | coveralls"
@@ -48,7 +47,8 @@
     "replace-homedir": "^1.0.0",
     "semver-greatest-satisfied-range": "^1.1.0",
     "v8flags": "^3.2.0",
-    "yargs": "^7.1.0"
+    "yargs": "^8.0.2",
+    "ansi-regex": "3.0.1"
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.5.0",
@@ -74,6 +74,9 @@
     },
     "strip-ansi": {
       "ansi-regex": "3.0.1"
+    },
+    "yargs": {
+      "yargs-parser": "^13.1.2"
     }
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "lint": "eslint .",
     "prepublish": "marked-man --name gulp docs/CLI.md > gulp.1",
+    "pretest": "npm run lint",
     "test": "mocha --async-only --timeout 5000 test/lib test",
     "cover": "nyc --reporter=lcov --reporter=text-summary npm test",
     "coveralls": "nyc --reporter=text-lcov npm test | coveralls"


### PR DESCRIPTION
This is a small PR that fixes a few high and critical dependency vulnerabilities discovered by Snyk:

```λ snyk-win.exe test https://github.com/gulpjs/gulp-cli                                                                              
                                                                                                                                    
Testing https://github.com/gulpjs/gulp-cli...                                                                                       
                                                                                                                                    
✗ High severity vulnerability found in unset-value                                                                                  
  Description: Prototype Pollution                                                                                                  
  Info: https://security.snyk.io/vuln/SNYK-JS-UNSETVALUE-2400660                                                                    
  Introduced through: matchdep@2.0.0, liftoff@3.1.0                                                                                 
  From: matchdep@2.0.0 > micromatch@3.1.10 > snapdragon@0.8.2 > base@0.11.2 > cache-base@1.0.1 > unset-value@1.0.0                  
  From: matchdep@2.0.0 > micromatch@3.1.10 > braces@2.3.2 > snapdragon@0.8.2 > base@0.11.2 > cache-base@1.0.1 > unset-value@1.0.0   
  From: matchdep@2.0.0 > micromatch@3.1.10 > extglob@2.0.4 > snapdragon@0.8.2 > base@0.11.2 > cache-base@1.0.1 > unset-value@1.0.0  
  and 12 more...                                                                                                                    
                                                                                                                                    
✗ High severity vulnerability found in ansi-regex                                                                                   
  Description: Regular Expression Denial of Service (ReDoS)                                                                         
  Info: https://security.snyk.io/vuln/SNYK-JS-ANSIREGEX-1583908                                                                     
  Introduced through: yargs@7.1.2                                                                                                   
  From: yargs@7.1.2 > string-width@1.0.2 > strip-ansi@3.0.1 > ansi-regex@2.1.1                                                      
  From: yargs@7.1.2 > cliui@3.2.0 > strip-ansi@3.0.1 > ansi-regex@2.1.1                                                             
  From: yargs@7.1.2 > cliui@3.2.0 > string-width@1.0.2 > strip-ansi@3.0.1 > ansi-regex@2.1.1                                        
  and 2 more...               ```
```


The fix requires overriding some transitive dependencies, upgrading yargs, and adding the correct version of ansi-regex as a main dependency rather than a transitive dependency.                                                                              