### PR TITLE
chore: Add deprecated warning for gulplog v1 messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 var fs = require('fs');
 var path = require('path');
 var log = require('gulplog');
+var oldLog = require('gulplog-v1');
 
 var Liftoff = require('liftoff');
 var interpret = require('interpret');
@@ -117,7 +118,8 @@ function onPrepare(env) {
   env = overrideEnvFlagsByConfigAndCliOpts(env, cfg, opts);
 
   // Set up event listeners for logging again after configuring.
-  toConsole(log, env.config.flags);
+  toConsole(log, env.config.flags, false);
+  toConsole(oldLog, env.config.flags, true);
 
   cli.execute(env, env.nodeFlags, onExecute);
 }

--- a/lib/shared/log/to-console.js
+++ b/lib/shared/log/to-console.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var chalk = require('chalk');
 var fancyLog = require('fancy-log');
 
 /* istanbul ignore next */
@@ -20,14 +21,42 @@ function cleanup(log) {
   function removeListeners(level) {
     if (level === 'error') {
       log.removeListener(level, noop);
-      log.removeListener(level, fancyLog.error);
+      log.removeListener(level, onError);
+      log.removeListener(level, onErrorDeprecated);
     } else {
-      log.removeListener(level, fancyLog);
+      log.removeListener(level, onLog);
+      log.removeListener(level, onLogDeprecated);
     }
   }
 }
 
-function toConsole(log, opts) {
+var deprecatedPrinted = false;
+
+function onError(msg) {
+  fancyLog.error(msg);
+}
+
+function onErrorDeprecated(msg) {
+  if (!deprecatedPrinted) {
+    fancyLog(chalk.yellow("gulplog v1 is deprecated. Please help your plugins update!"));
+    deprecatedPrinted = true;
+  }
+  fancyLog.error(msg);
+}
+
+function onLog(msg) {
+  fancyLog(msg);
+}
+
+function onLogDeprecated(msg) {
+  if (!deprecatedPrinted) {
+    fancyLog(chalk.yellow("gulplog v1 is deprecated. Please help your plugins update!"));
+    deprecatedPrinted = true;
+  }
+  fancyLog(msg);
+}
+
+function toConsole(log, opts, deprecated) {
   // Remove previous listeners to enable to call this twice.
   cleanup(log);
 
@@ -48,9 +77,9 @@ function toConsole(log, opts) {
     })
     .forEach(function(level) {
       if (level === 'error') {
-        log.on(level, fancyLog.error);
+        log.on(level, deprecated ? onErrorDeprecated : onError);
       } else {
-        log.on(level, fancyLog);
+        log.on(level, deprecated ? onLogDeprecated : onLog);
       }
     });
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "copy-props": "^4.0.0",
     "fancy-log": "^2.0.0",
     "gulplog": "^2.0.1",
+    "gulplog-v1": "npm:gulplog@1.0.0",
     "interpret": "^3.1.1",
     "liftoff": "^4.0.0",
     "mute-stdout": "^2.0.0",


### PR DESCRIPTION
Closes #249 

This wires up gulplog v1 handlers and prints a deprecation message when they are used.