### PR TITLE
chore: Move task list helper functions into the logTasks closure

### DIFF
--- a/lib/shared/log/tasks.js
+++ b/lib/shared/log/tasks.js
@@ -25,105 +25,105 @@ function logTasks(tree, opts, getTask) {
   };
 
   printTaskTree(tree, treeOpts);
-}
 
-function printTaskTree(tree, opts) {
-  var lines = [];
-  lines.push({ label: tree.label });
-  var maxLabelWidth = 0;
+  function printTaskTree(tree, opts) {
+    var lines = [];
+    lines.push({ label: tree.label });
+    var maxLabelWidth = 0;
 
-  tree.nodes.forEach(function(node, idx, arr) {
-    var isLast = idx === arr.length - 1;
-    var w = createTreeLines(node, lines, opts, 1, '', isLast);
-    maxLabelWidth = Math.max(maxLabelWidth, w || 0);
-  });
-
-  lines.forEach(function(line) {
-    var s = line.label;
-    if (line.desc) {
-      var spaces = ' '.repeat(maxLabelWidth - line.label.length) + '  ';
-      s += spaces + line.desc;
-    }
-    log.info(s);
-  });
-}
-
-function createTreeLines(node, lines, opts, depth, bars, isLast) {
-  var task = { label: node.label, bars: bars, depth: depth };
-  if (depth === 1) {
-    var t = opts.getTask(node.label);
-    task.desc = t.description;
-    task.flags = t.flags;
-  }
-
-  var isLeaf = isLeafNode(node, depth, opts);
-
-  var maxLabelWidth = addTaskToLines(task, lines, isLast, isLeaf);
-
-  if (!isLeaf) {
-    bars += (isLast ? '  ' : '│ ');
-    node.nodes.forEach(function(node, idx, arr) {
+    tree.nodes.forEach(function(node, idx, arr) {
       var isLast = idx === arr.length - 1;
-      createTreeLines(node, lines, opts, depth + 1, bars, isLast);
+      var w = createTreeLines(node, lines, opts, 1, '', isLast);
+      maxLabelWidth = Math.max(maxLabelWidth, w || 0);
+    });
+
+    lines.forEach(function(line) {
+      var s = line.label;
+      if (line.desc) {
+        var spaces = ' '.repeat(maxLabelWidth - line.label.length) + '  ';
+        s += spaces + line.desc;
+      }
+      log.info(s);
     });
   }
 
-  return maxLabelWidth;
-}
+  function createTreeLines(node, lines, opts, depth, bars, isLast) {
+    var task = { label: node.label, bars: bars, depth: depth };
+    if (depth === 1) {
+      var t = opts.getTask(node.label);
+      task.desc = t.description;
+      task.flags = t.flags;
+    }
 
-function addTaskToLines(task, lines, isLast, isLeaf) {
-  var taskBars = task.bars + (isLast ? '└' : '├') + '─';
-  if (isLeaf) {
-    taskBars += '─ ';
-  } else {
-    taskBars += '┬ ';
-  }
+    var isLeaf = isLeafNode(node, depth, opts);
 
-  var line = {};
-  if (task.depth === 1) {
-    line.label = chalk.white(taskBars) + chalk.white(task.label);
-  } else {
-    line.label = chalk.white(taskBars) + chalk.cyan(task.label);
-  }
-  if (typeof task.desc === 'string' && task.desc) {
-    line.desc = chalk.white(task.desc);
-  }
-  lines.push(line);
+    var maxLabelWidth = addTaskToLines(task, lines, isLast, isLeaf);
 
-  var maxLabelWidth = line.label.length
+    if (!isLeaf) {
+      bars += (isLast ? '  ' : '│ ');
+      node.nodes.forEach(function(node, idx, arr) {
+        var isLast = idx === arr.length - 1;
+        createTreeLines(node, lines, opts, depth + 1, bars, isLast);
+      });
+    }
 
-  if (!isObject(task.flags)) {
     return maxLabelWidth;
   }
 
-  var flagBars = task.bars;
-  if (isLast) {
-    flagBars += '  ';
-  } else {
-    flagBars += '│ ';
-  }
+  function addTaskToLines(task, lines, isLast, isLeaf) {
+    var taskBars = task.bars + (isLast ? '└' : '├') + '─';
+    if (isLeaf) {
+      taskBars += '─ ';
+    } else {
+      taskBars += '┬ ';
+    }
 
-  if (isLeaf) {
-    flagBars += '  ';
-  } else {
-    flagBars += '│ ';
-  }
-
-  Object.entries(task.flags).sort(flagSorter).forEach(addFlagsToLines);
-
-  function addFlagsToLines(ent) {
-    if (typeof ent[0] !== 'string' || !ent[0]) return;
     var line = {};
+    if (task.depth === 1) {
+      line.label = chalk.white(taskBars) + chalk.white(task.label);
+    } else {
+      line.label = chalk.white(taskBars) + chalk.cyan(task.label);
+    }
+    if (typeof task.desc === 'string' && task.desc) {
+      line.desc = chalk.white(task.desc);
+    }
     lines.push(line);
-    line.label = chalk.white(flagBars) + chalk.magenta(ent[0]);
 
-    maxLabelWidth = Math.max(maxLabelWidth, line.label.length);
+    var maxLabelWidth = line.label.length
 
-    if (typeof ent[1] !== 'string' || !ent[1]) return;
-    line.desc = chalk.white('…' + ent[1]);
+    if (!isObject(task.flags)) {
+      return maxLabelWidth;
+    }
+
+    var flagBars = task.bars;
+    if (isLast) {
+      flagBars += '  ';
+    } else {
+      flagBars += '│ ';
+    }
+
+    if (isLeaf) {
+      flagBars += '  ';
+    } else {
+      flagBars += '│ ';
+    }
+
+    Object.entries(task.flags).sort(flagSorter).forEach(addFlagsToLines);
+
+    function addFlagsToLines(ent) {
+      if (typeof ent[0] !== 'string' || !ent[0]) return;
+      var line = {};
+      lines.push(line);
+      line.label = chalk.white(flagBars) + chalk.magenta(ent[0]);
+
+      maxLabelWidth = Math.max(maxLabelWidth, line.label.length);
+
+      if (typeof ent[1] !== 'string' || !ent[1]) return;
+      line.desc = chalk.white('…' + ent[1]);
+    }
+
+    return maxLabelWidth;
   }
-
-  return maxLabelWidth;
 }
 
 function isLeafNode(node, depth, opts) {


### PR DESCRIPTION
This moves the archy-like helper functions into the logTasks closure. This will reduce the diff in my prototype since we need access to `getMessages`.