### PR TITLE
chore: Revert options & yargs parser changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,9 @@
 
 var fs = require('fs');
 var path = require('path');
-var log = require('gulplog');
 
+var log = require('gulplog');
+var yargs = require('yargs');
 var Liftoff = require('liftoff');
 var interpret = require('interpret');
 var v8flags = require('v8flags');
@@ -12,7 +13,7 @@ var chalk = require('chalk');
 var exit = require('./lib/shared/exit');
 var tildify = require('./lib/shared/tildify');
 var makeTitle = require('./lib/shared/make-title');
-var parser = require('./lib/shared/options/parser');
+var cliOptions = require('./lib/shared/options/cli-options');
 var completion = require('./lib/shared/completion');
 var cliVersion = require('./package.json').version;
 var toConsole = require('./lib/shared/log/to-console');
@@ -52,7 +53,18 @@ var cli = new Liftoff({
   },
 });
 
-var opts = parser.argv;
+var usage =
+  '\n' + chalk.bold('Usage:') +
+  ' gulp ' + chalk.blue('[options]') + ' tasks';
+
+var parser = yargs
+  .help(false)
+  .version(false)
+  .detectLocale(false)
+  .usage(usage)
+  .options(cliOptions);
+
+var opts = parser.parse();
 
 cli.on('preload:before', function(name) {
   log.info('Preloading external module:', chalk.magenta(name));

--- a/lib/shared/options/cli-options.js
+++ b/lib/shared/options/cli-options.js
@@ -1,11 +1,6 @@
 'use strict';
 
 var chalk = require('chalk');
-var yargs = require('yargs');
-
-var usage =
-  '\n' + chalk.bold('Usage:') +
-  ' gulp ' + chalk.blue('[options]') + ' tasks';
 
 var options = {
   help: {
@@ -121,8 +116,4 @@ var options = {
   }
 };
 
-var parser = yargs
-    .help(false).version(false).detectLocale(false)
-    .usage(usage).options(options);
-
-module.exports = parser;
+module.exports = options;

--- a/test/fixtures/logging.js
+++ b/test/fixtures/logging.js
@@ -1,7 +1,9 @@
 var log = require('gulplog');
+var yargs = require('yargs');
 var toConsole = require('../../lib/shared/log/to-console');
+var cliOptions = require('../../lib/shared/options/cli-options');
 
-var opts = require('../../lib/shared/options/parser').argv;
+var opts = yargs.options(cliOptions).parse();
 
 toConsole(log, opts);
 


### PR DESCRIPTION
This moves the yargs parser logic back into the `index.js` file. I want to try cleaning up the CLI help in my translations prototype and the indirection of throwing an error was confusing for me.