### PR TITLE
fix: Ensure the logger is wired up before running liftoff

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,6 +66,9 @@ var parser = yargs
 
 var opts = parser.parse();
 
+// Set up event listeners for logging temporarily.
+toConsole(log, opts);
+
 cli.on('preload:before', function(name) {
   log.info('Preloading external module:', chalk.magenta(name));
 });

--- a/test/config-description.js
+++ b/test/config-description.js
@@ -48,7 +48,7 @@ describe('config: description', function() {
       expect(err).toBeNull();
       expect(stderr).toEqual('');
       var expected = fs.readFileSync(path.join(expectedDir, 'output2.txt'), 'utf-8');
-      expect(sliceLines(stdout, 1)).toEqual(expected);
+      expect(sliceLines(stdout, 2)).toEqual(expected);
       done(err);
     }
   });


### PR DESCRIPTION
It seems that #159 broke logging of the loader include since liftoff will emit events before a logger is set up. I've re-added the initial logger construction to catch these cases.

We might need to revisit the Liftoff events for the next major version to avoid this.