### PR TITLE
chore!: Only allow js variants for .gulp config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Add `gulp --completion=fish | source` to `~/.config/fish/config.fish`.
 
 ## Compilers
 
-You can find a list of supported languages at https://github.com/gulpjs/interpret. If you would like to add support for a new language, send pull requests/open issues on that project.
+You can find a list of supported JavaScript variant languages in [Interpret][interpret-js-variants]. If you would like to add support for a new language, send pull requests/open issues on that project.
 
 ## Environment
 
@@ -99,7 +99,7 @@ The CLI adds `process.env.INIT_CWD` which is the original cwd it was launched fr
 
 ## Configuration
 
-Configuration is supported through the use of a `.gulp.*` file (e.g. `.gulp.json`, `.gulp.yml`). You can find a list of supported languages at https://github.com/gulpjs/interpret.
+Configuration is supported through the use of a `.gulp.*` file (e.g. `.gulp.js`, `.gulp.ts`). You can find a list of supported JavaScript variant languages in [Interpret][interpret-js-variants].
 
 A configuration file from the current working directory (`cwd`) or above are selected before a configuration file from the home directory (`~`).
 
@@ -224,6 +224,9 @@ __Some flags only work with gulp 4 and will be ignored when invoked against gulp
 
 MIT
 
+<!-- prettier-ignore-start -->
+[interpret-js-variants]: https://github.com/gulpjs/interpret#jsvariants
+<!-- prettier-ignore-end -->
 
 <!-- prettier-ignore-start -->
 [downloads-image]: https://img.shields.io/npm/dm/gulp-cli.svg?style=flat-square

--- a/index.js
+++ b/index.js
@@ -38,13 +38,13 @@ var cli = new Liftoff({
     {
       name: '.gulp',
       path: '.',
-      extensions: interpret.extensions,
+      extensions: interpret.jsVariants,
       findUp: true,
     },
     {
       name: '.gulp',
       path: '~',
-      extensions: interpret.extensions,
+      extensions: interpret.jsVariants,
     },
   ],
 });

--- a/test/fixtures/.gulp.js
+++ b/test/fixtures/.gulp.js
@@ -1,0 +1,3 @@
+module.exports = {
+  description: "gulp-cli/test/fixtures"
+};

--- a/test/fixtures/.gulp.json
+++ b/test/fixtures/.gulp.json
@@ -1,3 +1,0 @@
-{
-  "description" : "gulp-cli/test/fixtures"
-}

--- a/test/fixtures/config/flags/continue/f/.gulp.js
+++ b/test/fixtures/config/flags/continue/f/.gulp.js
@@ -1,0 +1,5 @@
+module.exports = {
+  flags: {
+    continue: false
+  }
+};

--- a/test/fixtures/config/flags/continue/f/.gulp.json
+++ b/test/fixtures/config/flags/continue/f/.gulp.json
@@ -1,5 +1,0 @@
-{
-  "flags": {
-    "continue": false
-  }
-}

--- a/test/fixtures/config/flags/continue/t/.gulp.js
+++ b/test/fixtures/config/flags/continue/t/.gulp.js
@@ -1,0 +1,5 @@
+module.exports = {
+  flags: {
+    continue: true
+  }
+};

--- a/test/fixtures/config/flags/continue/t/.gulp.json
+++ b/test/fixtures/config/flags/continue/t/.gulp.json
@@ -1,5 +1,0 @@
-{
-  "flags": {
-    "continue": true
-  }
-}

--- a/test/fixtures/config/flags/gulpfile/autoload-fail/.gulp.js
+++ b/test/fixtures/config/flags/gulpfile/autoload-fail/.gulp.js
@@ -1,0 +1,3 @@
+module.exports = {
+  gulpfile: "./other_dir/gulpfile.coffee"
+};

--- a/test/fixtures/config/flags/gulpfile/autoload-fail/.gulp.json
+++ b/test/fixtures/config/flags/gulpfile/autoload-fail/.gulp.json
@@ -1,3 +1,0 @@
-{
-  "gulpfile": "./other_dir/gulpfile.coffee"
-}

--- a/test/fixtures/config/flags/gulpfile/autoload/.gulp.js
+++ b/test/fixtures/config/flags/gulpfile/autoload/.gulp.js
@@ -1,0 +1,3 @@
+module.exports = {
+  gulpfile: "other_folder/gulpfile-exports.babel.js"
+};

--- a/test/fixtures/config/flags/gulpfile/autoload/.gulp.json
+++ b/test/fixtures/config/flags/gulpfile/autoload/.gulp.json
@@ -1,3 +1,0 @@
-{
-  "gulpfile": "other_folder/gulpfile-exports.babel.js"
-}

--- a/test/fixtures/config/flags/gulpfile/cwd/.gulp.js
+++ b/test/fixtures/config/flags/gulpfile/cwd/.gulp.js
@@ -1,0 +1,3 @@
+module.exports = {
+  gulpfile: "../is/here/gulpfile-by-cwd-cfg.js"
+};

--- a/test/fixtures/config/flags/gulpfile/cwd/.gulp.json
+++ b/test/fixtures/config/flags/gulpfile/cwd/.gulp.json
@@ -1,3 +1,0 @@
-{
-  "gulpfile": "../is/here/gulpfile-by-cwd-cfg.js"
-}

--- a/test/fixtures/config/flags/gulpfile/override-by-cliflag/.gulp.js
+++ b/test/fixtures/config/flags/gulpfile/override-by-cliflag/.gulp.js
@@ -1,0 +1,3 @@
+module.exports = {
+  gulpfile: "../cwd/gulpfile.js"
+};

--- a/test/fixtures/config/flags/gulpfile/override-by-cliflag/.gulp.json
+++ b/test/fixtures/config/flags/gulpfile/override-by-cliflag/.gulp.json
@@ -1,3 +1,0 @@
-{
-  "gulpfile": "../cwd/gulpfile.js"
-}

--- a/test/fixtures/config/flags/gulpfile/prj/.gulp.js
+++ b/test/fixtures/config/flags/gulpfile/prj/.gulp.js
@@ -1,0 +1,3 @@
+module.exports = {
+  gulpfile: "../is/here/gulpfile-by-prj-cfg.js"
+};

--- a/test/fixtures/config/flags/gulpfile/prj/.gulp.json
+++ b/test/fixtures/config/flags/gulpfile/prj/.gulp.json
@@ -1,3 +1,0 @@
-{
-  "gulpfile": "../is/here/gulpfile-by-prj-cfg.js"
-}

--- a/test/fixtures/config/flags/logLevel/L/.gulp.js
+++ b/test/fixtures/config/flags/logLevel/L/.gulp.js
@@ -1,0 +1,5 @@
+module.exports = {
+  flags: {
+    logLevel: 1
+  }
+}

--- a/test/fixtures/config/flags/logLevel/L/.gulp.json
+++ b/test/fixtures/config/flags/logLevel/L/.gulp.json
@@ -1,5 +1,0 @@
-{
-  "flags": {
-    "logLevel": 1
-  }
-}

--- a/test/fixtures/config/flags/logLevel/LL/.gulp.js
+++ b/test/fixtures/config/flags/logLevel/LL/.gulp.js
@@ -1,0 +1,5 @@
+module.exports = {
+  flags: {
+    logLevel: 2
+  }
+};

--- a/test/fixtures/config/flags/logLevel/LL/.gulp.json
+++ b/test/fixtures/config/flags/logLevel/LL/.gulp.json
@@ -1,5 +1,0 @@
-{
-  "flags": {
-    "logLevel": 2
-  }
-}

--- a/test/fixtures/config/flags/logLevel/LLL/.gulp.js
+++ b/test/fixtures/config/flags/logLevel/LLL/.gulp.js
@@ -1,0 +1,5 @@
+module.exports = {
+  flags: {
+    logLevel: 3
+  }
+};

--- a/test/fixtures/config/flags/logLevel/LLL/.gulp.json
+++ b/test/fixtures/config/flags/logLevel/LLL/.gulp.json
@@ -1,5 +1,0 @@
-{
-  "flags": {
-    "logLevel": 3
-  }
-}

--- a/test/fixtures/config/flags/nodeFlags/array/.gulp.js
+++ b/test/fixtures/config/flags/nodeFlags/array/.gulp.js
@@ -1,0 +1,3 @@
+module.exports = {
+  nodeFlags: ["--lazy", "--trace-deprecation"]
+}

--- a/test/fixtures/config/flags/nodeFlags/array/.gulp.json
+++ b/test/fixtures/config/flags/nodeFlags/array/.gulp.json
@@ -1,3 +1,0 @@
-{
-  "nodeFlags": ["--lazy", "--trace-deprecation"]
-}

--- a/test/fixtures/config/flags/preload/array/.gulp.js
+++ b/test/fixtures/config/flags/preload/array/.gulp.js
@@ -1,6 +1,6 @@
-{
-  "preload": [
+module.exports = {
+  preload: [
     "./preload_one",
     "./preload_two"
   ]
-}
+};

--- a/test/fixtures/config/flags/preload/join-flags/.gulp.js
+++ b/test/fixtures/config/flags/preload/join-flags/.gulp.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preload: [
+    "./preload_two"
+  ]
+};

--- a/test/fixtures/config/flags/preload/join-flags/.gulp.json
+++ b/test/fixtures/config/flags/preload/join-flags/.gulp.json
@@ -1,5 +1,0 @@
-{
-  "preload": [
-    "./preload_two"
-  ]
-}

--- a/test/fixtures/config/flags/preload/string/.gulp.js
+++ b/test/fixtures/config/flags/preload/string/.gulp.js
@@ -1,0 +1,3 @@
+module.exports = {
+  preload: "./preload"
+};

--- a/test/fixtures/config/flags/preload/string/.gulp.json
+++ b/test/fixtures/config/flags/preload/string/.gulp.json
@@ -1,3 +1,0 @@
-{
-  "preload": "./preload"
-}

--- a/test/fixtures/config/flags/preload/with-cwd/.gulp.js
+++ b/test/fixtures/config/flags/preload/with-cwd/.gulp.js
@@ -1,0 +1,3 @@
+module.exports = {
+  preload: "../preload"
+};

--- a/test/fixtures/config/flags/preload/with-cwd/.gulp.json
+++ b/test/fixtures/config/flags/preload/with-cwd/.gulp.json
@@ -1,3 +1,0 @@
-{
-  "preload": "../preload"
-}

--- a/test/fixtures/config/flags/series/f/.gulp.js
+++ b/test/fixtures/config/flags/series/f/.gulp.js
@@ -1,0 +1,5 @@
+module.exports = {
+  flags: {
+    series: false
+  }
+};

--- a/test/fixtures/config/flags/series/f/.gulp.json
+++ b/test/fixtures/config/flags/series/f/.gulp.json
@@ -1,5 +1,0 @@
-{
-  "flags": {
-    "series": false
-  }
-}

--- a/test/fixtures/config/flags/series/t/.gulp.js
+++ b/test/fixtures/config/flags/series/t/.gulp.js
@@ -1,0 +1,5 @@
+module.exports = {
+  flags: {
+    series: true
+  }
+};

--- a/test/fixtures/config/flags/series/t/.gulp.json
+++ b/test/fixtures/config/flags/series/t/.gulp.json
@@ -1,5 +1,0 @@
-{
-  "flags": {
-    "series": true
-  }
-}

--- a/test/fixtures/config/flags/silent/f/.gulp.js
+++ b/test/fixtures/config/flags/silent/f/.gulp.js
@@ -1,0 +1,5 @@
+module.exports = {
+  flags: {
+    silent: false
+  }
+};

--- a/test/fixtures/config/flags/silent/f/.gulp.json
+++ b/test/fixtures/config/flags/silent/f/.gulp.json
@@ -1,5 +1,0 @@
-{
-  "flags": {
-    "silent": false
-  }
-}

--- a/test/fixtures/config/flags/silent/t/.gulp.js
+++ b/test/fixtures/config/flags/silent/t/.gulp.js
@@ -1,0 +1,5 @@
+module.exports = {
+  flags: {
+    silent: true
+  }
+};

--- a/test/fixtures/config/flags/silent/t/.gulp.json
+++ b/test/fixtures/config/flags/silent/t/.gulp.json
@@ -1,5 +1,0 @@
-{
-  "flags": {
-    "silent": true
-  }
-}

--- a/test/fixtures/config/flags/sortTasks/f/.gulp.js
+++ b/test/fixtures/config/flags/sortTasks/f/.gulp.js
@@ -1,0 +1,6 @@
+module.exports = {
+  gulpfile: "../../../../gulpfiles/gulpfile-4.js",
+  flags: {
+    sortTasks: false
+  }
+};

--- a/test/fixtures/config/flags/sortTasks/f/.gulp.json
+++ b/test/fixtures/config/flags/sortTasks/f/.gulp.json
@@ -1,6 +1,0 @@
-{
-  "gulpfile": "../../../../gulpfiles/gulpfile-4.js",
-  "flags": {
-    "sortTasks": false
-  }
-}

--- a/test/fixtures/config/flags/sortTasks/t/.gulp.js
+++ b/test/fixtures/config/flags/sortTasks/t/.gulp.js
@@ -1,0 +1,6 @@
+module.exports = {
+  gulpfile: "../../../../gulpfiles/gulpfile-4.js",
+  flags: {
+    sortTasks: true
+  }
+};

--- a/test/fixtures/config/flags/sortTasks/t/.gulp.json
+++ b/test/fixtures/config/flags/sortTasks/t/.gulp.json
@@ -1,6 +1,0 @@
-{
-  "gulpfile": "../../../../gulpfiles/gulpfile-4.js",
-  "flags": {
-    "sortTasks": true
-  }
-}

--- a/test/fixtures/config/flags/tasksDepth/.gulp.js
+++ b/test/fixtures/config/flags/tasksDepth/.gulp.js
@@ -1,0 +1,6 @@
+module.exports = {
+  gulpfile: "../../../gulpfiles/gulpfile-4.js",
+  flags: {
+    tasksDepth: 4
+  }
+};

--- a/test/fixtures/config/flags/tasksDepth/.gulp.json
+++ b/test/fixtures/config/flags/tasksDepth/.gulp.json
@@ -1,6 +1,0 @@
-{
-  "gulpfile": "../../../gulpfiles/gulpfile-4.js",
-  "flags": {
-    "tasksDepth": 4
-  }
-}

--- a/test/fixtures/config/foo/bar/.gulp.js
+++ b/test/fixtures/config/foo/bar/.gulp.js
@@ -1,0 +1,3 @@
+module.exports = {
+  description: "Description by .gulp.json in directory foo/bar"
+};

--- a/test/fixtures/config/foo/bar/.gulp.json
+++ b/test/fixtures/config/foo/bar/.gulp.json
@@ -1,3 +1,0 @@
-{
-  "description": "Description by .gulp.json in directory foo/bar"
-}

--- a/test/fixtures/gulpfiles/.gulp.js
+++ b/test/fixtures/gulpfiles/.gulp.js
@@ -1,0 +1,3 @@
+module.exports = {
+  description: "gulp-cli/test/fixtures/gulpfiles"
+};

--- a/test/fixtures/gulpfiles/.gulp.json
+++ b/test/fixtures/gulpfiles/.gulp.json
@@ -1,3 +1,0 @@
-{
-  "description" : "gulp-cli/test/fixtures/gulpfiles"
-}


### PR DESCRIPTION
This restricts the `.gulp` config files to just JS variants. Since we're likely going to support translations and theming via functions as per #260, we only want to support variants that can define the functions.

@sttk tagging you here for feedback but I'm going to get this merged so I can update #260