### PR TITLE
Fix top level await not using `import()`

### DIFF
--- a/lib/shared/require-or-import.js
+++ b/lib/shared/require-or-import.js
@@ -23,7 +23,8 @@ function requireOrImport(path, callback) {
     if (pathToFileURL && importESM) {
       // Because e.code is undefined on nyc process.
       /* istanbul ignore else */
-      if (e.code === 'ERR_REQUIRE_ESM' || process.env.NYC_CONFIG) {
+      // Check 'ERR_REQUIRE_ASYNC_MODULE' if on node v22.12.0 or later to allow importing from files using top level await.
+      if (e.code === 'ERR_REQUIRE_ESM' || process.env.NYC_CONFIG || e.code === 'ERR_REQUIRE_ASYNC_MODULE') {
         // This is needed on Windows, because import() fails if providing a Windows file path.
         var url = pathToFileURL(path);
         importESM(url).then(function(esm) { callback(null, esm); }, callback);


### PR DESCRIPTION
Fixes #268 which is broken on node v22.12.0 and later(works on <= v22.11.0). Gulp cli was trying to use `require()`, failing and not trying to fallback to `import()` since the error code changed. Previously gulp would detect the error and attempt to use `import()`.

This makes it detect the new error code in node v22.12.0 and later. Keeps the old behavior to support older node versions as well.

See node change log which describes the changes that lead to this.

https://nodejs.org/en/blog/release/v22.12.0#requireesm-is-now-enabled-by-default